### PR TITLE
🔒 security(talos): bind etcd metrics endpoint to loopback

### DIFF
--- a/kubernetes/talos/machineconfig.yaml.j2
+++ b/kubernetes/talos/machineconfig.yaml.j2
@@ -144,7 +144,7 @@ cluster:
     extraArgs:
       auto-compaction-mode: periodic
       auto-compaction-retention: "1h"
-      listen-metrics-urls: http://0.0.0.0:2381
+      listen-metrics-urls: http://127.0.0.1:2381
   proxy:
     disabled: true
     image: registry.k8s.io/kube-proxy:{{ ENV.KUBERNETES_VERSION }}


### PR DESCRIPTION
## What

Bind etcd `listen-metrics-urls` to `127.0.0.1:2381` instead of `0.0.0.0:2381` so the **unauthenticated** etcd metrics endpoint is reachable only from the node itself — not from any LAN host and not from arbitrary pods.

```diff
-      listen-metrics-urls: http://0.0.0.0:2381
+      listen-metrics-urls: http://127.0.0.1:2381
```

File: `kubernetes/talos/machineconfig.yaml.j2:147` (single source — no node override touches it).

## Why

The endpoint was unauthenticated on all interfaces. This roadmap item scopes it to trusted listeners.

**No monitoring regression:** etcd is **not** scraped by Prometheus today — confirmed against live state, not assumed:
- `kube-prometheus-stack` chart: `kubeEtcd.enabled: false`, `defaultRules.rules.etcd: false` (`kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml`)
- No etcd `ServiceMonitor` / `ScrapeConfig` / `PodMonitor` anywhere under `kubernetes/apps/observability/`
- Live Prometheus `/api/v1/targets?state=active` → 53 active targets, **0 etcd-related**; Prometheus CR selectors are all `{}` so nothing is hidden by filter

Loopback bind is strictly more secure than the host-firewall-gate alternative the roadmap note floated (pods cannot reach host loopback either) and has no dependency on the separate `host-firewall-baseline` item.

## Verification (dry-run)

`just talos render-config k8s-cp0` renders the etcd block with `listen-metrics-urls: http://127.0.0.1:2381` (line 144 of rendered output). Source diff is authoritative:

```
git --no-pager diff kubernetes/talos/machineconfig.yaml.j2
@@ -144,7 +144,7 @@
       auto-compaction-retention: "1h"
-      listen-metrics-urls: http://0.0.0.0:2381
+      listen-metrics-urls: http://127.0.0.1:2381
```

## ⚠️ Apply is NOT in this PR's automated scope

This change takes effect only via a **human-approved** `just talos apply-node k8s-cp0`. That step:
- is **cluster-mutating** and gated by `.claude/settings.json` policy (requires explicit per-invocation approval),
- restarts **etcd** (etcd does not hot-reload listen addresses) — a brief control-plane blip on this single-CP node, **not** a full node reboot. Pick a maintenance moment.

Rollback: revert this commit and re-apply (`just talos apply-node k8s-cp0`); etcd restarts again and exposure is restored.

Closes roadmap item `docs/roadmap/etcd-metrics-endpoint-binding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)