### PR TITLE
refactor(observability): drop pushgateway StatefulSet+PVC, alerts are TSDB-sourced

### DIFF
--- a/basic-memory/docs/roadmap/crowdsec-alert-tsdb-sourced.md
+++ b/basic-memory/docs/roadmap/crowdsec-alert-tsdb-sourced.md
@@ -5,7 +5,7 @@ permalink: home-ops/docs/roadmap/crowdsec-alert-tsdb-sourced
 topic: Source the CrowdSec blocklist-import freshness alerts from the Prometheus TSDB
   with range-vector queries so they are immune to Pushgateway relay restarts, then
   revert the Pushgateway to stateless.
-status: in-progress
+status: done
 priority: medium
 area: observability, security
 created: 2026-08-06
@@ -17,7 +17,7 @@ relates_to: '[[crowdsec-blocklist-import]]'
 ## Metadata (observation-form, schema validation)
 
 - [topic] Source the CrowdSec blocklist-import freshness alerts from the Prometheus TSDB with range-vector queries so they are immune to Pushgateway relay restarts; revert the Pushgateway to stateless.
-- [status] in-progress
+- [status] done
 - [priority] medium
 - [area] observability, security
 - [created] 2026-08-06
@@ -118,3 +118,14 @@ The gate question: does anything OTHER than crowdsec-blocklist-import push to th
 - [delivered] GREEN GATE: `just k8s test-prom-rules` → "All promtool rule tests passed" (crowdsec module: "SUCCESS: 8 rules found" / "SUCCESS"); pre-commit on the 2 files (yamlfmt, yamllint, gitleaks, promtool-rule-tests) all Passed, no reformatting.
 - [not-delivered] P3 (stateless Pushgateway) + orphaned PVC cleanup are OUT OF SCOPE for this branch — the user handles the PVC cleanup later. P3 stays tracked here, gated by the verification step above (GATE PASSES).
 - [status] proposed → in-progress. P1+P2 done; P3 pending separate work.
+
+
+## Delivery — P3 (2026-08-06)
+
+- [delivered] P3 landed on branch `refactor/pushgateway-stateless` (off main after #4133 merge commit `8f510f653`). Code commit `33944e7ee` (signed, "Good git" signature) — `♻️ refactor(observability): drop pushgateway StatefulSet+PVC, alerts are TSDB-sourced`, 1 file changed, 7 deletions(-).
+- [delivered] Removed from `kubernetes/apps/observability/prometheus-pushgateway/app/helmrelease.yaml`: `runAsStatefulSet: true`, the whole `persistentVolume` block (enabled/size/storageClass), and the false 2-line comment claiming "StatefulSet + PVC so pushed metrics survive a pod restart". Kept: serviceMonitor (namespace + honorLabels: true), securityContext, containerSecurityContext, resources, podLabels, automountServiceAccountToken, serviceAccount. No `extraArgs` / `--persistence.file` added (the relay-not-store fix is rejected; Prometheus is SSOT).
+- [delivered] PRE-FLIGHT writable-filesystem finding (verified against chart 3.7.0 templates): with `runAsStatefulSet: false` + `persistentVolume.enabled: false` (chart defaults once the overrides are removed), `templates/_helpers.tpl` renders the `storage-volume` as `emptyDir: {}` mounted at `/data` (the `$storageVolumeAsPVCTemplate := and .Values.runAsStatefulSet .Values.persistentVolume.enabled` guard is false, so the `else` branch emits emptyDir). `readOnlyRootFilesystem: true` therefore still has a writable mount — no CrashLoopBackOff. The pushgateway binary with no `--persistence.file` writes nothing at runtime (confirmed in Task 1: /data empty, cmdline `/bin/pushgateway` no args), so the emptyDir is harmless.
+- [delivered] Service name unchanged: `templates/service.yaml` uses `prometheus-pushgateway.fullname` regardless of `runAsStatefulSet`; only the `clusterIP: None` (Headless) line is dropped when `runAsStatefulSet=false`, giving a normal ClusterIP Service. The importer target `prometheus-pushgateway.observability.svc.cluster.local:9091` resolves either way. `templates/statefulset.yaml` is gated on `if .Values.runAsStatefulSet` so it no longer renders; `templates/deployment.yaml` renders instead.
+- [delivered] GREEN GATE: `just k8s test-prom-rules` -> "All promtool rule tests passed" (crowdsec 8 rules SUCCESS — untouched, as expected); pre-commit on the touched file (yamlfmt, yamllint, gitleaks, end-of-file-fixer, etc.) all Passed, no auto-fix.
+- [not-delivered] Orphaned PVC `storage-volume-prometheus-pushgateway-0` (bound, 1Gi, democratic-csi-local-hostpath, Retain policy) is NOT deleted by this change — the StatefulSet removal does not garbage-collect it. It is a separate manual ops step for the Maestro, AFTER the HelmRelease reconciles to the Deployment.
+- [status] in-progress -> done. P1+P2+P3 all shipped; the only remaining item is the one-shot PVC cleanup (Maestro ops step, not a manifest change).

--- a/kubernetes/apps/observability/prometheus-pushgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-pushgateway/app/helmrelease.yaml
@@ -11,13 +11,6 @@ spec:
     name: prometheus-pushgateway
   values:
     replicaCount: 1
-    # StatefulSet + PVC so pushed metrics survive a pod restart — otherwise a restart
-    # blanks the blocklist-import freshness signal and false-fires CrowdSecBlocklistImportMetricsAbsent.
-    runAsStatefulSet: true
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-      storageClass: democratic-csi-local-hostpath
     automountServiceAccountToken: false
     serviceAccount:
       create: false


### PR DESCRIPTION
## What is removed and why

The Pushgateway is a stateless relay/cache, not a durable store. Prometheus is the single source of truth, and since #4133 the `CrowdSecBlocklistImport*` alerts read the TSDB with range-vector queries (`absent_over_time[26h]`, `max_over_time[50h]`) — so a Pushgateway pod restart can no longer false-fire them.

This PR removes from `kubernetes/apps/observability/prometheus-pushgateway/app/helmrelease.yaml`:
- `runAsStatefulSet: true`
- the whole `persistentVolume` block (`enabled`/`size`/`storageClass`)
- the false 2-line comment claiming *"StatefulSet + PVC so pushed metrics survive a pod restart"*

The StatefulSet + 1Gi PVC was dead weight: `--persistence.file` was **never** set, so the binary ran in-memory-only and the `/data` mount was a no-op (verified: `/data` empty, cmdline `/bin/pushgateway` with no args). The removed comment described a property the chart never had and a concern #4133 made moot. No `extraArgs` / `--persistence.file` is added — the relay-not-store fix is explicitly rejected; Prometheus is SSOT.

Kept untouched: `serviceMonitor` (namespace + `honorLabels: true`), `securityContext`, `containerSecurityContext`, `resources`, `podLabels`, `automountServiceAccountToken`, `serviceAccount`, `replicaCount`.

## Pre-flight writable-filesystem finding (verified against chart 3.7.0)

The container runs `readOnlyRootFilesystem: true`; today the only writable mount is the `/data` PVC. Removing it is safe:

- `templates/_helpers.tpl` defines `storage-volume` via the guard `$storageVolumeAsPVCTemplate := and .Values.runAsStatefulSet .Values.persistentVolume.enabled`. With both overrides removed, the chart defaults (`runAsStatefulSet: false`, `persistentVolume.enabled: false`) make that guard false → the `else` branch renders **`emptyDir: {}`** for `storage-volume`, still mounted at `/data` (`persistentVolume.mountPath` default `/data`).
- So `readOnlyRootFilesystem: true` keeps a writable mount — **no CrashLoopBackOff**. The pushgateway binary with no `--persistence.file` writes nothing at runtime, so the emptyDir is harmless.

Service: `templates/service.yaml` uses `prometheus-pushgateway.fullname` regardless of `runAsStatefulSet`, so the Service **name is unchanged** (`prometheus-pushgateway`). Only the `clusterIP: None` (Headless) line is dropped when `runAsStatefulSet=false` → normal ClusterIP Service. The importer target `prometheus-pushgateway.observability.svc.cluster.local:9091` resolves either way. `templates/statefulset.yaml` is gated on `if .Values.runAsStatefulSet` and no longer renders; `templates/deployment.yaml` renders instead.

## Orphaned PVC cleanup — separate manual ops step (Maestro)

The bound PVC `storage-volume-prometheus-pushgateway-0` (1Gi, democratic-csi-local-hostpath) is **not** garbage-collected when the StatefulSet is removed (`persistentVolumeClaimRetentionPolicy: whenDeleted: Retain`). It will be deleted manually by the Maestro as a one-shot ops step **after** this HelmRelease reconciles to the Deployment. This PR does **not** delete it and adds no cluster-mutating change.

## flux-local CI diff expectation

StatefulSet `prometheus-pushgateway` removed; Deployment `prometheus-pushgateway` added (same labels/selector, `emptyDir` storage-volume, no `volumeClaimTemplates`); Service `prometheus-pushgateway` transitions Headless → ClusterIP (name/ports/selector unchanged); all other resources unchanged.

## Green gate

- `just k8s test-prom-rules` → `All promtool rule tests passed` (crowdsec 8 rules SUCCESS — untouched, as expected).
- `pre-commit run --files <helmrelease.yaml>` → all Passed (yamlfmt, yamllint, gitleaks, end-of-file-fixer, etc.), no auto-fix.
- Both commits signed (`33944e7ee` code, `a780a9a09` docs) — Good "git" signature, ED25519.

Roadmap note: `docs/roadmap/crowdsec-alert-tsdb-sourced` — status **done** (P1+P2+P3 all shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)