### PR TITLE
🐛 fix(envoy-gateway): drop the Recreate deployment strategy

### DIFF
--- a/kubernetes/apps/networking/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/app/helmrelease.yaml
@@ -27,12 +27,15 @@ spec:
         # default (read-only root filesystem, non-root 65532, drop ALL, no privilege
         # escalation, RuntimeDefault seccomp). Restating it here would only invite drift
         # from upstream — audit `helm show values` before adding anything back.
+        #
+        # No strategy override either. Recreate looks right for a single replica on one
+        # node, but switching an existing Deployment to it fails server-side apply: the
+        # API-server-defaulted spec.strategy.rollingUpdate survives the merge and "may
+        # not be specified when strategy type is 'Recreate'". Clearing it needs an
+        # out-of-band patch, which is not worth it for a 5m/192Mi surge replica.
         resources:
           requests:
             cpu: 5m
             memory: 192Mi
           limits:
             memory: 1024Mi
-        # Single-node: a rolling update would need a surge replica to schedule first.
-        strategy:
-          type: Recreate


### PR DESCRIPTION
Unblocks the Envoy Gateway v1.9.0 upgrade, which failed three times and rolled back:

```
Deployment.apps "envoy-gateway" is invalid: spec.strategy.rollingUpdate:
Forbidden: may not be specified when strategy `type` is 'Recreate'
```

Server-side apply merges `type: Recreate` onto a live Deployment whose
`spec.strategy.rollingUpdate` was defaulted in by the API server, and the merged
object is invalid. Clearing the stale field needs an out-of-band patch, which is
not worth it for a controller requesting 5m CPU / 192Mi — its surge replica
schedules on this node without trouble.

The Gateway API CRDs already moved to v1.6.1 (Helm applies CRDs ahead of the
templates and rollback does not revert them); the controller stayed on v1.8.3 and
never restarted, so there was no traffic impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)