### PR TITLE
feat(downloads): add recyclarr for sonarr/radarr config sync

### DIFF
--- a/basic-memory/docs/progress/arr-config-sync.md
+++ b/basic-memory/docs/progress/arr-config-sync.md
@@ -1,0 +1,225 @@
+---
+title: arr-config-sync
+type: note
+permalink: home-ops/docs/progress/arr-config-sync
+---
+
+
+# arr-config-sync — execution progress
+
+- [type] progress-note
+- [branch] feat/arr-config-sync
+- [roadmap] home-ops/docs/roadmap/arr-config-sync
+- [status] in-progress
+- [area] k8s-workloads, external-secrets
+- [created] 2026-08-17
+
+## Goal
+
+Deploy **recyclarr** as a Flux CronJob under `kubernetes/apps/downloads/recyclarr/` that syncs Sonarr/Radarr quality profiles + custom formats (and naming/media-management) from the TRaSH guide into the live `downloads` instances, declaratively from GitOps. Preserve the **Hungarian-dubbed (magyar szinkron) over-weighting** that currently lives out-of-band in the live instances.
+
+## Decisions (Maestro, 2026-08-16/17)
+
+- **Engine**: recyclarr (not Profilarr). User decision.
+- **Hungarian over-weighting** (both Sonarr + Radarr, GitOps): a LOCAL custom format with `LanguageSpecification`, `fields.value: 22` (Hungarian language ID, stable), loaded via recyclarr `resource_providers` (settings.yml + per-service JSON CF files), assigned a HIGH positive score in the quality profile. Quality-profile `language` field is NOT manually settable in recyclarr YAML → scored CF is the uniform path. Logic: `magyar 4K > magyar 1080p > nem-magyar 4K > nem-magar 1080p` (Hungarian dominates quality, but 4K still leads within Hungarian).
+- **Base presets**: Sonarr `WEB-2160p` (trash_id `d1498e7d189fbe6c7110ceaabb7473e6`); Radarr `UHD Bluray + WEB 2160p`. User wants 4K preferred but balanced file size (not huge UHD remux), 1080p/720p not excluded (fallback).
+- **Radarr size-tuning** (Slice D3, Maestro ratify): prefer WEB-2160p over UHD-BluRay-remux within the profile (quality ordering / CF scores) for balanced size.
+- **24h Delay Profile stays MANUAL** (out-of-band, UI) — recyclarr does NOT sync delay profiles (verified: sync pipelines are CF/QualityProfiles/QualitySizes/MediaNaming/MediaManagement only). Documented exception; one-time stable setting.
+- Current (sub-optimal) profiles are NOT preserved wholesale — fresh config built from guide presets + Hungarian CF (user: "nem a legjobbak").
+
+## Slices — done + Maestro-verified
+
+- **Slice A — app skeleton**: `ks.yaml`, `app/{kustomization,helmrelease}.yaml`. DEVIATION (ratified): NO per-app `ocirepository.yaml` — app-template OCIRepository is shared via `components/common/repos/app-template` (sonarr/radarr use the same). HelmRelease minimal-spec (chartRef/interval/values only). CronJob @daily, image recyclarr:8.7.1 digest-pinned, hardened securityContext (UID 10001, readOnlyRootFilesystem, drop ALL), `RECYCLARR_DATA_DIR: /tmp` emptyDir. Verified: kustomize build green, yamllint green, no dangling refs.
+- **Slice B — ExternalSecret + env**: `app/externalsecret.yaml` (ClusterSecretStore onepassword-connect, target `recyclarr-secret`, data: 1PW item `radarr`/`radarr_api_key` → `RADARR_API_KEY`, `sonarr`/`sonarr_api_key` → `SONARR_API_KEY`); helmrelease env `SONARR_API_KEY`+`RADARR_API_KEY` via secretKeyRef to `recyclarr-secret`; kustomization resources updated. Verified: kustomize build green, yamllint green, refs consistent.
+- **Slice D1 — Hungarian local CF**: `app/config/settings.yml` (resource_providers sonarr+radarr → `/config/custom-formats/{sonarr,radarr}`); `app/config/custom-formats/{sonarr,radarr}/hungarian.json` (`trash_id: home-ops-hungarian-language`, LanguageSpecification value 22, required). Verified: yamllint 0, json ok, NOT in kustomization, kustomize build unchanged.
+
+## Next slices (after checkpoint /clear)
+
+- **D2 — preset include files**: fetch `sonarr/templates/web-2160p.yml` + `radarr/templates/uhd-bluray-web.yml` from recyclarr/config-templates repo → save as `app/config/includes/{sonarr-web-2160p,radarr-uhd-bluray-web}.yml`. Not in kustomization.
+- **D3 — recyclarr.yml** (Maestro ratify on score + Radarr tuning): instances (base_url internal svc, api_key `!env_var`, delete_old_custom_formats true), `include` the preset files, custom_formats referencing `home-ops-hungarian-language` with high score assign_scores_to the profile, Radarr size-tuning, quality_definition.
+- **D4 — config mount**: ConfigMap from `app/config/` → mount in cronjob at `/config`; set recyclarr config-discovery (recyclarr.yml + settings.yml path, env/arg); wire kustomization; CNP (sonarr/radarr callee-side egress for recyclarr) deferred to Slice E.
+
+## Open / ratify-gates
+
+- D3: Hungarian CF score value (recommend high, e.g. +1000, to dominate quality differential) — Maestro ratify.
+- D3: Radarr WEB-2160p-over-remux tuning specifics — Maestro ratify.
+- Optional: light live recon to confirm Hungarian=22 in the running instances (not required; 22 is stable).
+- No commit yet — files on branch feat/arr-config-sync, uncommitted. Commit at checkpoint/session-end (worker does the commit; Maestro does not).
+
+## Maestro-side correction
+
+2026-08-16 `write_note(overwrite:true)` accidentally clobbered the pre-existing 368-line roadmap note (docs/roadmap/arr-config-sync). Recovered from main via git checkout; session additions re-appended properly. BM safety protocol: "Updated note" ⇒ STOP, never overwrite blind.
+
+## Relations
+
+- implements [[home-ops/docs/roadmap/arr-config-sync]]
+- relates_to [[home-ops/docs/areas/k8s-workloads]]
+- relates_to [[home-ops/docs/areas/external-secrets]]
+
+
+## Session 2026-08-17 — all code slices delivered + Maestro-verified (GitOps complete)
+
+### Slices done + independently verified (verify-don't-trust)
+
+- **D2 — preset include files**: fetched upstream `config-templates` sonarr/radarr presets verbatim. **SUPERSEDED + deleted in D3** — verify-don't-trust caught that those files are FULL-schema templates (`sonarr: web-2160p:` wrapper + `base_url`/`api_key` placeholders, the input to `recyclarr config create`), NOT valid `include: config:` files (which expect the instance-level, wrapper-less form). Decision: switch D3 to direct declaration, drop the include mechanism entirely. The `app/config/includes/` directory was deleted.
+- **D3 — recyclarr.yml** (direct declaration, no includes): Sonarr WEB-2160p (`trash_id d1498e7d...`) + Radarr UHD Bluray+WEB (`trash_id 64fb5f98...`) guide-backed profiles; `custom_format_groups.add` = the preset's uncommented active groups (4 sonarr: Golden Rule UHD / Language Profiles / Streaming HD-UHD boost / Unwanted; 2 radarr: Golden Rule UHD / Unwanted); local Hungarian CF (`home-ops-hungarian-language`) scored **+1000** on each profile; `delete_old_custom_formats: true`; `quality_definition` type-only (TRaSH guide DEFAULT sizes). Wrote byte-identical to brief; `includes/` deleted; yamllint 0; not in any kustomization resources.
+- **D4 — config mount**: `app/kustomization.yaml` — `configMapGenerator` (`recyclarr-config`, 4 files: recyclarr.yml, settings.yml, sonarr-hungarian.json, radarr-hungarian.json) + `generatorOptions.disableNameSuffixHash: true`. `app/helmrelease.yaml` — `persistence.config-files` (configMap + globalMounts/subPath) projecting the 4 flat ConfigMap keys to `/config/{recyclarr.yml,settings.yml,custom-formats/sonarr/hungarian.json,custom-formats/radarr/hungarian.json}`; `tmp` emptyDir kept (RECYCLARR_DATA_DIR=/tmp). `args: [sync]` unchanged. Verified: kustomize build generates the ConfigMap (name `recyclarr-config` no hash) with all 4 keys + embedded content (home-ops-hungarian-language, resource_providers, recyclarr.yml header all present in render); 4 subPath mounts present; parent build OK.
+- **E — CNP admission**: edited the two EXISTING callee-side CNPs (sonarr port 8989, radarr port 7878) — added a 4th `fromEndpoints.matchLabels` block (`k8s:io.kubernetes.pod.namespace: downloads` + `app.kubernetes.io/name: recyclarr`) after seerr; updated header comments to list recyclarr. Verified: both CNPs now 4 fromEndpoints (bazarr/prowlarr/seerr/recyclarr), recyclarr block labels correct, toPorts + endpointSelector intact; kustomize build OK for sonarr/radarr/downloads; pre-commit green (yamlfmt/yamllint/gitleaks passed, nothing reformatted). No recyclarr egress CNP needed — no policy selects its pod → Cilium default-allow egress.
+
+### Ratified decisions this session
+
+- **Max release size**: accept TRaSH guide defaults — the prior ~11GB/hour custom cap is NOT replicated (user decision 2026-08-17). recyclarr Quality Sizes pipeline would have honored a `quality_definition.qualities[].max` override (MB/min, runtime-normalized; 11GB/h ≈ 183 MB/min), but the guide default is preferred over a custom override.
+- **Hungarian CF score**: **+1000** (user decision) — strongly over-weights Hungarian-dubbed releases against the quality differential, preserving the existing intent.
+- **No-include approach**: direct declaration in recyclarr.yml (preset group selections inlined) instead of `include: config:` — forced by the wrapper-mismatch D2 finding.
+
+### Open design assumption (not locally testable)
+
+- recyclarr image default config location = `/config` (bjw-s reference runs `sync` with no `--config`, mounts at /config; settings.yml auto-discovered in the same dir). **If a first run reports "config not found", the one-line fix is `args: [sync, --config, /config/recyclarr.yml]`.** Documented here; not applied.
+
+### Branch state
+
+- All code slices (A, B, D1, D3, D4, E) done + Maestro-verified. Files on `feat/arr-config-sync`, UNCOMMITTED.
+- `git status --short`: modified roadmap.md, downloads/kustomization.yaml, sonarr+radarr CNPs; untracked: recyclarr/ tree + progress/.
+- No commit, no push, no PR yet — Maestro does not commit (worker's lane). **Awaiting user decision: commit (code + docs) + push + open PR. Merge to main = Flux reconcile = deploy → user-gated separately.**
+
+### Next
+
+- User decision on commit + push + draft PR. After approval, worker runs commit-doc-commit (code commit → this progress note already updated by Maestro via BM MCP → docs commit `git add basic-memory/`) + push + open PR (draft). Merge is terminal and user-gated.
+## Implementation decisions (2026-08-17) — spec-driven recyclarr.yml rewrite
+
+Context: the prior recyclarr.yml (Sonarr WEB-2160p `d1498e7d…` / Radarr UHD Bluray+WEB `64fb5f98…`, HUN +1000, TRaSH default quality sizes) was reviewed and found not to enforce the user's goals (exclude gigantic 4K, keep 720p/1080p fallback, HUN > quality > size). A closed spec was ratified and implemented. recyclarr.yml is rewritten in place; hungarian.json + settings.yml are UNCHANGED (verified: pure LanguageSpecification value 22, score lives in recyclarr.yml). All changes UNCOMMITTED, local-only, awaiting review + commit + first-sync (with a VolSync snapshot of the radarr/sonarr PVCs first).
+
+### Radarr — SQP-1 (2160p) on sqp-uhd size set
+- quality_definition.type: `sqp-uhd` (was `movie`). Profile SQP-1 (2160p) `5128baeb2b081b72126bc8482b2a86a0` (was UHD Bluray+WEB `64fb5f98…`).
+- Profile (TRaSH JSON, verified): allows Bluray-2160p, WEB 2160p, Bluray|WEB-1080p (incl. WEBDL-720p, WEBRip-720p), Bluray-720p → 720p/1080p fallback PRESERVED; excludes Remux-2160p, BR-DISK, HDTV, low-res. cutoffFormatScore 10000, minFormatScore 1000, upgradeAllowed true, trash_score_set `sqp-1-2160p`.
+- upgrade.allowed: true + until_score: 20000 (override cutoff → enables within-HUN upgrades 720p→1080p→2160p; HUN total 10000 < 20000).
+- Hard size caps (quality_definition.qualities[].max, MB/min): WEBDL-2160p / WEBRip-2160p / Bluray-2160p = 300; WEBDL-1080p / WEBRip-1080p = 150. DEFAULTS were 2000 for all (non-binding — did NOT exclude gigantic files). 720p has NO entry in the sqp-uhd size set → uncapped (acceptable: 720p is the small fallback; capping it risks rejecting the only available release). DEVIATION from spec's "720p:80" — impossible to express, documented.
+- custom_format_groups: Golden Rule UHD `ff204b…` (x265-HD blockers) + Unwanted SQP `15b1cf…` (was regular Unwanted `a3ac6af…`).
+- LQ/BR-DISK added EXPLICITLY as custom_formats (LQ `90a6f9a2…`, LQ Release Title `e204b80c…`, BR-DISK `ed38b889…`, score -10000 → SQP-1 profile): the SQP Unwanted group `15b1cf…` LACKS LQ/BR-DISK (verified), so without this the junk-rejection invariant would not hold.
+- HUN `home-ops-hungarian-language` score +10000 → SQP-1 profile (was +1000).
+- min_format_score: 0 OVERRIDE (profile default 1000). DEVIATION, load-bearing: with only Golden Rule + Unwanted SQP groups (no tier/HDR/audio groups, per spec), legitimate non-HUN releases score 0 < 1000 → ALL non-HUN would be rejected, breaking the 720p/1080p fallback. Lowering to 0 restores fallback. Tradeoff: loses SQP tier-based quality ranking (bad-group vs good-group 4K WEB-DL score equally); the hard cap + quality order + HUN still meet the stated goals. To restore pure SQP ranking later, add tier/HDR/audio groups (release-groups-hq, audio-formats, hdr-formats-*, required-repack-proper, optional-resolutions) and set min_format_score back to 1000.
+- media_management: `propers_and_repacks: do_not_prefer` ONLY. DEVIATION: spec requested recycle_bin / use_hardlinks / monitor_new_items / enable_media_info / auto_unmonitor_previous_downloads / delete_empty_series_folders — NONE exist in the recyclarr v8 media-management schema (additionalProperties:false; only propers_and_repacks). Verified against https://schemas.recyclarr.dev/v8/config/media-management.json . use_hardlinks is a Radarr UI setting not exposed by recyclarr; the qbit/radarr/sonarr shared NFS /media mount makes hardlinks work regardless.
+- media_naming: folder plex-imdb, movie {rename: true, standard: plex-imdb} (onedr0p verbatim).
+
+### Sonarr — WEB-2160p (Combined) on series size set
+- quality_definition.type: `series` (unchanged). Profile WEB-2160p (Combined) `c4cadd6b35b95f62c3d47a408e53e2f7` (was non-Combined WEB-2160p `d1498e7d…`).
+- Profile (TRaSH JSON, verified): allows WEB 2160p + WEB 1080p; DISABLES WEB 720p, Bluray, Remux, HDTV. minFormatScore 0, cutoffFormatScore 10000, cutoff "WEB 2160p", no trash_score_set (default scores).
+- qualities OVERRIDE (replaces the profile quality list): WEB 2160p > WEB 1080p > WEB 720p (all enabled) — RE-ENABLES 720p as fallback (phase-2 hard requirement; Combined disables it by design). upgrade.until_quality: "WEB 2160p", until_score: 20000. Tradeoff: hardcoded quality list does not track future guide updates to the Combined profile.
+- Hard size caps (series set, unlike sqp-uhd, HAS 720p): WEBDL-2160p / WEBRip-2160p = 200; WEBDL-1080p / WEBRip-1080p = 100; WEBDL-720p / WEBRip-720p = 50 (defaults 1000).
+- custom_format_groups: kept the 4 (Golden Rule UHD `e3f375…`, Language Profiles `74aff4…`, Streaming HD/UHD boost `85fae4…`, Unwanted `59c3af…`). The Sonarr Unwanted group `59c3af…` INCLUDES LQ/BR-DISK and lists WEB-2160p (Combined) in its include → junk rejection already covered (no explicit LQ/BR-DISK needed, unlike Radarr).
+- HUN score +10000 → Combined profile (was +1000). Default score set + no tier group → non-HUN positive sums are small; HUN dominates trivially.
+
+### HUN-score invariant math (priority: HUN > quality > size)
+- HUN = +10000; LQ = BR-DISK = -10000.
+- Radarr (min_format_score 0): LQ alone -10000 < 0 → rejected ✓. HUN alone 10000 ≥ 0 → accepted ✓. HUN+LQ = 0 ≥ 0 → accepted (edge case; HUN dubs are rarely LQ-tagged). Within-HUN upgrade: 10000 < until_score 20000 ✓ (720p HUN → 1080p HUN → 2160p HUN).
+- Sonarr (min_format_score 0): same as Radarr.
+- HUN dominates non-HUN: non-HUN releases score ~0 (Radarr, no tier CFs) or small positive (Sonarr, streaming/language CFs ≪ 10000) → any HUN release (10000) beats any non-HUN release. A HUN 720p (10000) beats a non-HUN 4K WEB-DL (~0) ✓ — the core HUN > quality requirement.
+- Raising min_format_score above 0 to also reject HUN+LQ would reject score-0 fallback releases (720p/1080p with no CFs) → breaks fallback. So min_format_score 0 is the correct lever; the HUN+LQ edge case is accepted by design.
+- Post-sync verify: confirm the actual tier/HDR/audio CF integers under the sqp-1-2160p score set do not produce a non-HUN sum ≥ 10000 (only relevant if tier groups are added later).
+
+### Validation
+- yamlfmt (conf .yamlfmt.yaml): clean (no content change, only EOF newline normalized).
+- yamllint (conf .yamllint.yaml): clean, exit 0.
+- recyclarr binary NOT installed locally → no live `recyclarr lint`/dry-run. Schema validation done by manual field-by-field verification against the v8 sub-schemas (media-management, media-naming-radarr, media-naming-sonarr, quality-definition, custom-formats, quality-profiles) at https://schemas.recyclarr.dev/v8/config/*.json , plus TRaSH guide JSON (quality-size/{sqp-uhd,series}, quality-profiles/{sqp-1-2160p,web-2160p-combined}, cf-groups). The `!env_var` tags and remote $refs make a generic JSON-schema validator impractical without pre-processing.
+- NOT synced: no `recyclarr sync` run, no cluster apply. Uncommitted in the working tree.
+
+### Open / verify-post-sync / review items
+- First real `recyclarr sync` MUST be preceded by a VolSync snapshot of both radarr and sonarr PVCs (delete_old_custom_formats + new profile/score writes rewrite live state).
+- Verify the SQP-1 profile does not grab unwanted Bluray-2160p encodes now that tier CFs are absent (rely on hard cap 300 MB/min + quality order). If compact 4K Bluray grabs are unwanted, add tier groups + restore min_format_score 1000.
+- Verify `upgrade.until_quality: "WEB 2160p"` (Sonarr) and the qualities override are accepted by recyclarr (group-name cutoff + replaced quality list).
+- Verify the local `home-ops-hungarian-language` CF resolves via settings.yml resource_providers and scores +10000 on both profiles post-sync.
+- Spec field-name deviations recorded above (media_management field set, 720p Radarr cap, min_format_score 0 override, Sonarr qualities override) — flagged for human review.
+
+
+## Correction decisions (2026-08-17, Maestro verify)
+
+Maestro verify-don't-trust on the manifest confirmed it matches the implementation report. This section records the correction decisions applied to the uncommitted working tree (STILL no commit/push/PR).
+
+### F1 -- HUN 10000 -> 9900 (both apps)
+Changed the local Hungarian CF score from +10000 to +9900 on BOTH the Sonarr (WEB-2160p Combined) and Radarr (SQP-1 2160p) profiles, plus the two recyclarr.yml comments that referenced +10000. This restores the LQ-rejection invariant: with min_format_score 0, HUN(9900) + LQ(-10000) = -100 < 0 -> a HUN+LQ release is REJECTED (no longer the "accepted edge case" the +10000 value left open). Zero cost: fallback score-0 >= 0 still works; HUN 9900 > ~0 (option A) still dominates; within-HUN upgrade 9900 < 20000 still preserved. BR-DISK stays excluded by the profile's quality-allow, independent of score.
+
+### F2 = A -- min_format_score 0 kept, NO tier CF groups (DECISION; no manifest change)
+Decision: keep min_format_score 0 on Radarr and do NOT add tier/HDR/audio CF groups (release-groups-hq, audio-formats, hdr-formats-*, required-repack-proper, optional-resolutions). Rationale: A is verified-safe now (non-HUN ~0, HUN dominates trivially, 720p/1080p fallback works); B's only gain is non-HUN release-group ranking (not requested) and it carries a real risk to the user's #1 priority (HUN > quality) because the sqp-1-2160p score-set integers are unverified (a top non-HUN combo could approach/exceed HUN=9900). Framework point 7c records B's re-verification path, so B remains a documented future enhancement -- A does not foreclose it. min_format_score 0 is REQUIRED for fallback: the ratified spec's minFormatScore 1000 + no tier CF groups would have rejected every non-HUN release (the phase-1 review missed this; the implementation report's deviation #3 caught it).
+
+### F4 -- Radarr upgrade.until_quality (VERIFY-GATED, applied)
+Added 'until_quality: WEB 2160p' to the Radarr SQP-1 (2160p) upgrade block (Sonarr already had it via the Combined profile's native cutoff). Goal: stop Radarr upgrading to Bluray-2160p; make the WEB-DL preference explicit. Verification evidence: (a) "WEB 2160p" is a named, allowed:true quality item in the SQP-1 (2160p) profile (group with [WEBRip-2160p, WEBDL-2160p]); (b) group-name cutoffs are the native valid form -- the Sonarr WEB-2160p (Combined) profile's native cutoff IS "WEB 2160p". The 300 MB/min cap on Bluray-2160p protects the size goal regardless. VERIFY-POST-SYNC: confirm the cutoff took effect after the first real sync (the SQP-1 native default cutoff is "Bluray-2160p", a single quality). JSON-schema validation (v8, 9 sub-schemas resolved) returned 0 errors; the until_quality sub-schema is {"type":"string"} (the schema cannot encode profile-specific quality names, so value validity rests on the profile-structure evidence above, not the schema).
+
+### F3 -- media_management v8 limitation (DOCUMENTATION ONLY; no manifest change)
+recyclarr v8 media_management syncs ONLY propers_and_repacks (schema additionalProperties:false). The user's other media-management preferences CANNOT be set via recyclarr and must be configured manually in the Radarr/Sonarr UI (not GitOps-managed; lost on PVC rebuild):
+- monitor_new_items: all (Sonarr), movieOnly (Radarr)
+- auto_unmonitor_previous_downloads: false (so cutoff upgrades keep running)
+- recycle_bin: false
+- use_hardlinks: RUNTIME-VERIFY on the NFS /media mount -- hardlinks over NFS are protocol/client-dependent and NOT guaranteed; if it fails the arr falls back to copy (double storage during seeding). (This corrects the earlier overconfident "use_hardlinks works via NFS /media regardless" claim.)
+- delete_empty_series_folders (Sonarr)
+- enable_media_info
+Buildarr (Terraform-like declarative arr-settings manager) evaluated-later for the non-recyclarr-syncable fields. No action now.
+
+### Validation
+- yamlfmt (.yamlfmt.yaml, dry): "No files will be changed" -- already formatted.
+- yamllint (.yamllint.yaml): clean, exit 0 (no output).
+- JSON-schema validate against https://schemas.recyclarr.dev/v8/config-schema.json (draft-07, 9 sub-schemas resolved, !env_var handled as string): 0 errors.
+- recyclarr binary lint/dry-run: NOT available (binary not installed); schema validation + manual field-by-field verification substituted. No real 'recyclarr sync' run.
+
+### Current state (unchanged)
+Files MODIFIED, NOT committed, NOT deployed, NOT synced. Pending: first real 'recyclarr sync' MUST be preceded by a VolSync snapshot of both the radarr and sonarr PVCs (delete_old_custom_formats + new profile/score writes rewrite live state).
+
+## Session 2026-08-17 (later) — DEEP-verify apply: 3 decisions (Ollama → Maestro, human-approved)
+Read-only deep-verify (delegation 3) surfaced 3 decisions; the human approved all three via the Maestro. Applied to the uncommitted working tree (still no commit/push/PR).
+
+1. **Item 1 — /config writable PVC.** `state/` (a config-dir artifact the recyclarr wiki says "should be backed up") must persist for `delete_old_custom_formats` cross-run cleanup; both reference repos (onedr0p + bjw-s) mount a WRITABLE PVC at /config for this. The `/config` PVC is created by the shared `components/volsync` component declared in `ks.yaml` (VolSync/Kopia backup to OVH S3), consistent with the *arr siblings, referenced via `persistence.config.existingClaim: recyclarr` mounted at /config. The 4 ConfigMap config files (recyclarr.yml, settings.yml, sonarr/radarr hungarian.json) are subPath-projected INTO the writable /config (paths unchanged). `RECYCLARR_DATA_DIR=/tmp` + `readOnlyRootFilesystem` + `args: [sync]` + `tmp` emptyDir for the data dir.
+
+2. **Item 2 — KEEP `type: sqp-uhd` (Radarr); do NOT switch to sqp-streaming.** Authoritative evidence from `TRaSH-Guides/Guides` `docs/json/radarr/quality-size/`: `sqp-streaming.json` INCLUDES 720p entries (WEBDL-720p/WBRip-720p, default max **85.7 MB/min**) while `sqp-uhd.json` has NO 720p entry. Switching would cap 720p at 85.7 MB/min, contradicting the uncapped-720p-fallback intent AND the "HUN > size" priority (a HUN 720p >85.7 MB/min would be rejected on size alone). The explicit 2160p/1080p `max` overrides (300/150) are identical under both types → the balanced-4K goal is unaffected. The official SQP-1 template uses sqp-streaming, but the templates accept its native 720p cap; our deviation (sqp-uhd) is deliberate, documented at recyclarr.yml:86, now backed by the size-set evidence. Sonarr `type: series` unchanged. Comment at recyclarr.yml:86 tightened to cite the 85.7 MB/min evidence.
+
+3. **Item 3 — UID 2000 → 10001.** bjw-s uses UID 2000 (so 2000 was a bjw-s reference copy, not random drift), but it contradicts the home-ops 10001 convention (runtime-baselines.md + 6 *arr siblings + roadmap intent) with no functional/shared-volume reason: recyclarr mounts only the ConfigMap + the /config PVC and shares no volume with the *arr stack; the image is rootless (native UID 1000, no PUID/PGID). All three UIDs (1000/2000/10001) work; 10001 is the documented standard. Manifest `runAsUser/runAsGroup/fsGroup` 2000 → 10001. No APP_UID/PUID/PGID env in the manifest → no ks.yaml postBuild substitute needed (confirmed).
+
+Post-deploy verify-gates (from deep-verify, still open): (a) first real `recyclarr sync` must follow a VolSync snapshot of the radarr + sonarr PVCs (delete_old_custom_formats rewrites live state); (b) verify the PVC + fsGroup 10001 lets recyclarr write /config/state; (c) verify recyclarr does NOT attempt to write /config/settings.yml (mounted read-only from ConfigMap) — if it does, settings.yml delivery needs rework; (d) confirm delete_old_custom_formats actually deletes stale CFs across runs now that state persists.
+
+Validation: pre-commit (yamlfmt + yamllint + gitleaks) PASS on the touched files (recyclarr.yml, kustomization.yaml, helmrelease.yaml, ks.yaml). NOT committed, NOT deployed, NOT synced.
+
+## Session 2026-08-17 — recyclarr VolSync wiring (ks.yaml)
+recyclarr's `/config` PVC is created by the shared `components/volsync` component (VolSync/Kopia backup to OVH S3), consistent with the *arr siblings — declared in `ks.yaml`, not via an app-local PVC manifest.
+
+### ks.yaml wiring
+- `components: - ../../../../components/volsync` (path resolves from `spec.path` `kubernetes/apps/downloads/recyclarr/app` → `kubernetes/components/volsync`, same depth as the siblings).
+- `dependsOn: [onepassword-connect (external-secrets), democratic-csi (kube-system)]`.
+- `postBuild.substitute: {APP: recyclarr}` — the only substitution; all other volsync values use the component defaults (capacity 1Gi, storageClass `democratic-csi-local-hostpath`, hourly schedule `0 * * * *`, default retention 24h/7d/2w/1m, mover UID/GID 10001).
+
+### Justified omissions vs the *arr siblings
+The *arr siblings (radarr/sonarr/bazarr) set `components: [volsync, gateway-oidc, zeroscaler]`, `dependsOn: [onepassword-connect, democratic-csi, pocket-id]`, `postBuild.substitute: {APP, APP_SUBDOMAIN}`. recyclarr intentionally omits:
+- **gateway-oidc + pocket-id**: recyclarr is an internal-only CronJob with no ingress/HTTPRoute — no OIDC gate to wire.
+- **zeroscaler**: scales Deployments to 0 off-hours; a CronJob is not scalable — no effect.
+- **APP_SUBDOMAIN**: no route → no subdomain.
+
+### helmrelease alignment
+`persistence.config.existingClaim: recyclarr` matches the PVC name the volsync component creates (claim name derived from APP → `recyclarr`); `runAsUser/runAsGroup/fsGroup: 10001` matches the volsync mover default UID.
+
+### Validation
+- pre-commit (yamlfmt + yamllint + gitleaks) PASS on ks.yaml, kustomization.yaml, helmrelease.yaml.
+- `flux build kustomization recyclarr --path kubernetes/apps/downloads/recyclarr/app --kustomization-file kubernetes/apps/downloads/recyclarr/ks.yaml --dry-run` → exit 0; renders the volsync resources: PersistentVolumeClaim name=recyclarr (matches `existingClaim: recyclarr`), ReplicationSource name=recyclarr (mover runAsUser 10001, repository recyclarr-volsync-secret), ReplicationDestination name=recyclarr-bootstrap, ExternalSecret name=recyclarr-volsync.
+- NOT committed, NOT deployed, NOT synced.
+
+
+## Session 2026-08-17 — merge-prep: review + VolSync snapshots + PR
+
+Best-practice review of the recyclarr config against TRaSH-Guides (Radarr + Sonarr profile/file-size/german-en pages) and the recyclarr v8 schema complete and verified:
+
+- **Sonarr (WEB-2160p Combined)**: full "exclude BAD quality" coverage natively — the Unwanted group (59c3af) carries AV1/LQ/LQ-RT/BR-DISK/Upscaled. HUN +9900, cutoff WEB 2160p, 720p re-enabled as fallback.
+- **Radarr (SQP-1 2160p, sqp-uhd)**: covered after the explicit AV1+3D add (-10000) — the SQP Unwanted group (15b1cf) lacks AV1/3D/LQ/BR-DISK, so all four are added explicitly at -10000 on profile 5128baeb2b081b72126bc8482b2a86a0. Golden Rule UHD (ff204b) supplies x265-no-HDR/DV -10000.
+- **Human decisions applied**: AV1=exclude, 3D=exclude, HDR/DV boost CFs left out (keep non-HUN ~0, HUN dominance trivial; option B re-add would require re-verifying +9900 against sqp-1-2160p score-set), min-floors skipped (Upscaled CF covers fake/upscaled 4K).
+- **HUN-score invariant**: HUN 9900 + LQ -10000 = -100 < 0 → HUN+LQ rejected; +9900 (not +10000) preserves fallback and within-HUN upgrade to WEB 2160p.
+- **Size caps**: explicit quality_definition max overrides reject bloated encodes (Radarr 2160p=300/1080p=150; Sonarr 2160p=200/1080p=100/720p=50 MB/min); 720p left uncapped on Radarr (sqp-uhd) as the small HUN fallback.
+
+**Pre-merge VolSync snapshots taken (rollback point)** — both manual triggers patched ReplicationSource in namespace `downloads`; confirmed Successful via kopia snapshot list:
+
+- Radarr: snapshot `cfad81a28a76337854b8de229acb64df` @ 2026-08-17T20:14:14Z (491.6 MiB, latest-1).
+- Sonarr: snapshot `9c4a4f97a38252586592a8b11d8e967a` @ 2026-08-17T20:11:13Z (440.5 MiB, latest-1).
+
+Code committed (11 kubernetes/ files, explicit pathspecs): `✨ feat(downloads): add recyclarr for sonarr/radarr config sync` — recyclarr CronJob (digest-pinned 8.7.1, hardened UID 10001, @daily), local HUN CF +9900, max-cap quality defs, AV1/3D/LQ/BR-DISK -10000, ESO-delivered arr API keys from 1Password, callee-side CiliumNetworkPolicy admitting recyclarr to radarr/sonarr. Closes the arr-config-sync roadmap.
+
+PR opened against `main` (transition plan + review verdict in PR body). First manual recyclarr sync pending — **Maestro holds merge until green CI + confirmed snapshots**; merge + first sync are the Maestro's, not the worker's.
+
+### Next
+- Wait for Maestro merge (after green CI).
+- Post-merge: verify recyclarr CronJob live + ExternalSecret synced, then trigger first sync manually.
+- Post-sync verify: read back live *arr profiles (HUN +9900, cutoff WEB 2160p, unwanted -10000); remap library naming + delete old sub-optimal profiles in UI.
+- Rollback path: `just volsync restore …` from the pre-merge snapshots above if the first sync goes wrong.

--- a/basic-memory/docs/roadmap/arr-config-sync.md
+++ b/basic-memory/docs/roadmap/arr-config-sync.md
@@ -5,364 +5,102 @@ permalink: home-ops/docs/roadmap/arr-config-sync
 tags:
 - roadmap
 - recyclarr
-- profilarr
 - sonarr
 - radarr
 - arr-stack
 - config-sync
-- proposed
+- in-progress
 ---
 
-# *arr quality-config sync — Recyclarr vs Profilarr
+# *arr quality-config sync — Recyclarr (current state)
 
 ## Metadata (observation-form, schema validation)
 
-- [topic] Automate Sonarr/Radarr quality-profile, custom-format, quality-definition and naming synchronization from a curated upstream guide — evaluating two mutually exclusive candidates: Recyclarr (CronJob, YAML-in-git) and Profilarr (long-running web app, PCD git database)
-- [status] proposed
+- [topic] Automate Sonarr/Radarr quality-profile, custom-format, quality-definition and naming synchronization from the TRaSH guide into the live `downloads` Arr instances, declaratively from GitOps via recyclarr.
+- [status] implementation complete (uncommitted on branch `feat/arr-config-sync`; awaiting human review → commit → push → PR → first recyclarr sync with a VolSync snapshot)
 - [priority] medium
-- [scope] Pick ONE config-sync owner for the two Arr instances in the `downloads` namespace, then deliver it: Recyclarr as a `type: cronjob` app-template workload driven by a ConfigMap-mounted `recyclarr.yml`, or Profilarr as a two-container UI app (app + parser) with a VolSync-backed `/config` PVC, an `envoy-internal` route behind the `gateway-oidc` gate, and a Pocket ID client. Either path additionally requires new 1Password properties for the Sonarr/Radarr API keys plus callee-side CiliumNetworkPolicy edits on sonarr and radarr.
-- [confidence] high on the repo-side facts (re-verified against the live tree 2026-08-04) and on the Profilarr/Recyclarr capability surface (upstream source, OpenAPI spec, release + registry APIs); medium on Profilarr's operational maturity trajectory, low on whether its `/config` can run under an arbitrary (≠1000) UID
-- [assessed] 2026-08-04 — Profilarr added as a second candidate; the original 2026-06-13 Recyclarr survey re-verified and corrected in six places (see Corrections)
-- [note] This note supersedes `docs/roadmap/recyclarr` (renamed to `docs/roadmap/arr-config-sync` on 2026-08-04) because the item is no longer "adopt Recyclarr" but "choose a config-sync owner".
+- [scope] recyclarr CronJob under `kubernetes/apps/downloads/recyclarr/` (ConfigMap-mounted `recyclarr.yml`), ExternalSecret for the Sonarr/Radarr API keys, local Hungarian-dub CF, and callee-side CiliumNetworkPolicy edits on sonarr + radarr.
+- [confidence] high on repo-side facts and recyclarr capability surface (upstream + v8 schema verified 2026-08-17)
+- [note] This note is a clean current-state record (2026-08-17). The pre-decision Recyclarr-vs-Profilarr comparison, the survey corrections, and the execution-slice history are preserved in git history (pre-2026-08-17 cleanup) for reference.
 
-## Context
+## Decision — Recyclarr over Profilarr (2026-08-16)
 
-Sonarr and Radarr quality profiles and custom formats drift from curated recommendations
-over time, and hand-maintaining them through two web UIs is error-prone. Both candidate
-tools fix the same problem — reconcile profiles/custom formats/quality definitions from a
-curated upstream into the live Arr instances — but they sit at opposite ends of the
-GitOps spectrum:
+- [decision] Recyclarr (CronJob, YAML-in-git) chosen as the single config-sync owner; Profilarr evaluated and rejected. User decision 2026-08-16.
+- Rejection rationale: Profilarr trades declarative config for a UI-owned SQLite state + plaintext credential store + internal HTTP surface + a single-owner TRaSH conversion-repo dependency, and its v2 line had no stable release at decision time. Recyclarr is fully declarative, rootless, no listening surface, reads TRaSH directly, native fit with the repo's UID-10001 / read-only posture.
+- Re-evaluation gate for Profilarr (future): (a) publishes a major tag, (b) resumes a stable release cadence, (c) offers declarative Arr-instance bootstrap (write endpoints under `/arr`).
+- Recyclarr model: CLI (`recyclarr sync`) one-shot container; desired state = `recyclarr.yml` in git; reads the TRaSH Guides repo directly; `!env_var` / `!file` interpolation for secrets; state/ persists on a writable `/config` PVC created by the shared `components/volsync` component (VolSync/Kopia backup to OVH S3), consistent with the *arr siblings; config files are ConfigMap-subPath-projected into the PVC.
 
-- **Recyclarr** is a CLI/one-shot container: the desired state is a `recyclarr.yml` in git,
-  the tool holds no state worth keeping, and it reads the TRaSH Guides repo directly.
-- **Profilarr** is a stateful web application: the desired state lives in a Git-backed
-  "PCD" dataset plus a local SQLite database, edited through a UI, with a built-in job
-  scheduler that pushes to the Arr instances.
+## Planning framework & priority order (szempontrendszer)
 
-They are **mutually exclusive per instance** (see below), so this is a choice, not a
-sequence.
+This framework records the CONSIDERATION FRAMEWORK used during planning — the priority order + governing principles — so a FUTURE change can be evaluated against this same framework: does this change respect HUN > quality > size? does it preserve 720p/1080p fallback? does it keep the HUN invariants? These are the governing rules for future changes.
 
-## Corrections to the previous survey (2026-06-13 → re-verified 2026-08-04)
+1. PRIORITY ORDER (hard): HUN dub > quality > size. The Hungarian-language release is the highest priority, ranked ABOVE quality — a HUN 720p/1080p must beat a non-HUN 4K/Remux. Size is the lowest-priority lever.
 
-The original note's config survey was materially wrong in six places. Corrected facts:
+2. SIZE-vs-QUALITY GOAL: balanced — EXCLUDE gigantic 4K / huge-bitrate / huge-file releases; but do NOT blanket-exclude lower resolutions. 720p and 1080p MUST remain acceptable as fallback, because content is frequently available ONLY in those qualities.
 
-- [correction] **Namespace.** Sonarr and Radarr are **not** in `media` — they live in
-  `kubernetes/apps/downloads/{sonarr,radarr}/` with `targetNamespace: downloads`
-  (`kubernetes/apps/downloads/sonarr/ks.yaml:33`, `.../radarr/ks.yaml:33`). The `media`
-  namespace holds Plex and its satellites. A config-sync app therefore belongs in
-  **`downloads`**, alongside its two consumers — which also keeps the CNP edits
-  same-namespace.
-- [correction] **Exposure.** Both HTTPRoutes attach to **`envoy-internal` only**
-  (`parentRefs` → `envoy-internal` in ns `networking`, `sectionName: https`;
-  `.../sonarr/app/helmrelease.yaml:69-85`). The old note claimed
-  `envoy-external + envoy-internal`. The Arr UIs are already LAN-only.
-- [correction] **Images.** Current pins are `ghcr.io/home-operations/sonarr:4.0.19.2995@sha256:…`
-  (`.../sonarr/app/helmrelease.yaml:35-36`) and
-  `ghcr.io/home-operations/radarr:6.4.0.10540@sha256:…` (`.../radarr/app/helmrelease.yaml:35-36`),
-  not the 4.0.17/6.2.0 pair recorded in June.
-- [correction] **Both apps already carry the two shared components.** `ks.yaml:12-13` on each
-  pulls in `../../../../components/volsync` and `../../../../components/gateway-oidc`, so
-  their only ExternalSecrets today are the generated `${APP}-volsync` and `${APP}-oidc`
-  (`kubernetes/components/volsync/externalsecret.yaml:6`,
-  `kubernetes/components/gateway-oidc/externalsecret.yaml:6`). Container securityContext is
-  the repo standard: UID/GID/fsGroup 10001, `runAsNonRoot`, `RuntimeDefault` seccomp,
-  `readOnlyRootFilesystem: true`, all caps dropped, `emptyDir` at `/tmp`
-  (`.../sonarr/app/helmrelease.yaml:20-27` and `:52-56`).
-- [correction] **The API-key gap is confirmed, not conditional.** An exhaustive
-  `api[-_]?key` grep across `kubernetes/apps/` finds only Mistral/OpenAI keys
-  (`selfhosted/paperless-gpt`, `selfhosted/mealie`) and the CrowdSec bouncer key — **no
-  Sonarr/Radarr API key is delivered by ExternalSecret anywhere**, and neither Arr
-  HelmRelease has an `env:` block at all. Homepage does not expose them either: its whole
-  `services.yaml` is injected as one 1Password field
-  (`selfhosted/homepage/app/externalsecret.yaml:20`, `dataFrom.extract.key: homepage`), so
-  any keys it uses are buried inside that blob rather than available as discrete
-  properties. **New 1Password properties are required for either candidate**; the old
-  note's "Option B — reuse existing items" is not available.
-- [correction] **CiliumNetworkPolicy work was missing entirely from the old note.** Sonarr's
-  CNP admits only `bazarr`, `prowlarr` and `seerr` on port 8989
-  (`.../sonarr/app/ciliumnetworkpolicy.yaml:14-28`); radarr's is the same shape. A new
-  syncer **must be added to both callees' `fromEndpoints` lists**, or its traffic is
-  dropped by the callee. This is the single easiest step to miss.
-- [confirmed] Recyclarr's `latest` tag really is gone in favour of major tags; the current
-  release is **v8.7.0 (2026-07-15)**, so `ghcr.io/recyclarr/recyclarr:8` remains the right
-  pin shape.
+3. REMUX / BR-DISK / LQ EXCLUSION: clean UHD Remux is undesired (size); BR-DISK (full disc images) and LQ (low-quality) releases are rejected via the Unwanted CF group (BR-DISK = -10000, LQ = -10000). Remux exclusion comes from the PROFILE (allowed qualities), not CFs — BR-DISK does not match clean remuxes. (Implementation note 2026-08-17: the Radarr SQP Unwanted group lacks LQ/BR-DISK, so they are added explicitly as custom_formats; see docs/progress/arr-config-sync.)
 
-## Candidate A — Recyclarr
+4. BEST-PRACTICE / REFERENCE-BASED: decisions are anchored to onedr0p/home-ops + bjw-s-labs/home-ops reference repos, TRaSH-Guides, and the recyclarr upstream config-templates. Prefer recyclarr's built-in recommended config blocks over hand-rolling. Do NOT copy bjw-s's 720p-dropping qualities override.
 
-- [reference] Upstream: [recyclarr/recyclarr](https://github.com/recyclarr/recyclarr) —
-  MIT, 2059 stars, 12 open issues, v8.7.0 (2026-07-15), pushed 2026-08-03.
-- **Model**: CLI (`recyclarr sync`) in a one-shot container. Desired state = `recyclarr.yml`
-  in git; instance URL **and** API key are declared in that YAML, with `!env_var` /
-  `!file` interpolation for the secret bits (`!file` since v7.5.0).
-- **Source of truth**: the **TRaSH Guides repo directly** — no conversion layer.
-- **Syncs**: quality definitions, quality profiles (guide templates by `trash_id` or
-  custom), custom formats + scores, **custom-format groups** (v8, auto-syncs whole
-  categories against guide-backed profiles), media naming, media management
-  (propers/repacks). Ships ~13 Sonarr and ~16 Radarr guide templates
-  (`recyclarr config create --template <name>`).
-- **Does not do**: Prowlarr (out of scope by design — indexers are orthogonal), regex
-  authoring/testing, release simulation, renaming, upgrade searches, drift reporting.
-- **Scheduling**: one global schedule (`@daily` default). In Kubernetes this becomes the
-  CronJob schedule instead.
-- **Rootless**: by design; PUID/PGID explicitly unsupported (use `--user`), which suits
-  this repo's fixed UID 10001 posture.
-- **State**: a config dir holding the cloned guide repo plus logs — nothing a human authored.
+5. PROFILE-CHOICE PRINCIPLE: SQP family for Radarr (SQP-1 2160p) + Combined for Sonarr (WEB-2160p Combined) — the quality-BALANCED presets that prefer WEB-DL, exclude remux, AND keep 1080p/720p fallback. This is deliberately OPPOSED to the quality-maximizing "UHD Bluray + WEB" (Radarr) and non-Combined "WEB-2160p" (Sonarr) presets, which forbid the 720p/1080p fallback.
 
-## Candidate B — Profilarr
+6. SIZE-CAP PRINCIPLE: the TRaSH quality-size default max (2000 MB/min ≈ 240 GB / 2h movie) is NON-BINDING — it does not exclude gigantic files. A real ceiling requires an explicit `quality_definition.qualities[].max` override. The ceiling applies to the TOP quality; lower qualities get proportionally lower caps. NEVER raise a `min` floor in a way that rejects 720p/1080p. (Implementation note 2026-08-17: the sqp-uhd size set has no 720p entry → 720p stays uncapped on Radarr; the Sonarr series set has 720p → capped at 50.)
 
-- [reference] Upstream: [Dictionarry-Hub/profilarr](https://github.com/Dictionarry-Hub/profilarr) —
-  AGPL-3.0, 2509 stars, 33 open issues + 5 PRs, default branch `develop`.
-- **Images**: `ghcr.io/dictionarry-hub/profilarr` plus an optional
-  `ghcr.io/dictionarry-hub/profilarr-parser` (C#/.NET) that mirrors Radarr/Sonarr release
-  parsing. `linux/amd64` + `linux/arm64`.
-- [observation] **The documented major tag does not exist.** The README advertises `latest`
-  / `develop` / exact / major tags, but the GHCR tag list contains only `2.0.0`…`2.0.9`,
-  `develop`, `latest` and buildcache entries — **no `2`, no `2.0`**. Pinning must therefore
-  use full semver + digest (which is the repo's house style anyway).
-- **Runtime**: long-running Deno 2 / SvelteKit service on **6868**; parser on **5000**.
-  Health endpoints `/api/v1/health` and `/health`.
-- **State** in `/config` (`APP_BASE_PATH`): SQLite `data/profilarr.db` (WAL), `logs/`,
-  `backups/`, and **cloned git repos** under `data/databases/{uuid}`. Write access is
-  mandatory (mkdir at start, WAL writes, `git clone/pull`, backup tarballs).
-- **UID**: the entrypoint runs a root path (PUID/PGID/UMASK + `chown -R /config`, then
-  `su-exec`) **and** a non-root fast path that skips all privilege operations. The baked-in
-  user is **1000**; the Dockerfile explicitly documents `runAsUser: 1000` for Kubernetes and
-  states that volume ownership must be handled externally (fsGroup / init container /
-  pre-provisioned perms). Support for an **arbitrary UID such as this repo's 10001 is
-  undocumented** — the non-root path only `mkdir`s and assumes `/config` is already
-  writable, so `fsGroup: 10001` would have to carry it.
-- **`readOnlyRootFilesystem`**: not vendor-documented, but **community-proven** — public
-  home-ops repos run it `true` with `runAsNonRoot`, UID/GID/fsGroup 1000 and an `emptyDir`
-  at `/tmp` for both containers.
-- **Auth**: `AUTH=on` (bcrypt + 7-day sliding sessions), `AUTH=oidc`
-  (`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`/`OIDC_DISCOVERY_URL`, `ORIGIN` mandatory,
-  callback `{ORIGIN}/auth/oidc/callback`), or `AUTH=off`. Plus a DB-backed local-network
-  bypass toggle and an `X-Api-Key` header scoped to `/api/` paths only.
-- **Source of truth**: **PCD** ("Profilarr Compliant Database") — a git repo of append-only
-  SQL ops plus a `pcd.json` manifest, replayed into an in-memory SQLite cache on every
-  compile. Layers: schema → base ops → tweaks → **user ops**. The primary dataset is
-  [Dictionarry-Hub/database](https://github.com/Dictionarry-Hub/database) (332 stars).
-- [observation] **TRaSH consumption is second-hand.** Profilarr cannot read the TRaSH Guides
-  repo; it consumes [Dictionarry-Hub/trash-pcd](https://github.com/Dictionarry-Hub/trash-pcd),
-  a conversion repo (MIT, 37 stars, single owner, branches `main`/`french`/`german`, last
-  pushed 2026-07-20). That is a freshness/abandonment dependency Recyclarr does not have.
-- **Local modifications survive upstream pulls** (they are user ops, never exported).
-  Conflicts resolve per `conflict_strategy`: `override` (default — user wins, conflicted op
-  regenerated against clean state, audited via `superseded_by_op_id`), `align` (upstream
-  wins), or `ask` (manual per-op review).
-- **Scheduling**: SQLite-backed serial job queue. Cron expressions per instance/section for
-  `arr.sync.*`, `arr.upgrade`, `arr.rename`, `arr.cleanup`, `arr.drift`; fixed minute
-  intervals for `arr.library.refresh` and `pcd.sync`; named schedules for backups and log
-  cleanup. Sync triggers: `manual`, `schedule`, `on_pull`.
-- **Sync semantics**: name-based matching, idempotent on retry, 3 instances in parallel,
-  sections sequential (custom formats before profiles). **No diff tracking and no rollback.**
-- **Extra capabilities Recyclarr has no equivalent for**: regex library with embedded
-  Regex101 test cases; custom-format testing against real release titles via the parser;
-  quality-profile **simulation/scoring** against real titles (TMDB metadata); automated
-  **upgrade searches**; **bulk rename** with dry-run preview; **delay profiles**; drift
-  detection against live Arr config; scheduled backups with retention (secrets stripped);
-  notifications to Discord/Telegram/Slack/ntfy/Pushover/Gotify/Apprise/webhook; a REST API
-  with an OpenAPI 3.1 spec.
+7. HUN-SCORE INVARIANTS (the bounds for any future HUN-value change):
+   (a) LQ/BR-DISK rejection MUST hold: HUN + (-10000) < minFormatScore. Under the chosen min_format_score 0 this gives HUN < 10000; HUN=9900 satisfies it (HUN+LQ = 9900 + (-10000) = -100 < 0, rejected). NEVER set HUN >= 10000 under min_score=0 -- it would let HUN+LQ >= 0 and accept a bad (LQ) Hungarian release. (Under a hypothetical minFormatScore 1000 the bound would be HUN < 11000, but min_score=0 is the implementation value.)
+   (b) Within-HUN upgrading MUST be preserved: HUN total < cutoffFormatScore. Chosen path: until_score raised to +20000 on BOTH apps (Sonarr + Radarr), so within-HUN upgrades are preserved; HUN=9900 < 20000 (OK).
+   (c) HUN MUST dominate realistic non-HUN quality sums. Under the chosen option A (NO tier/HDR/audio CF groups added), non-HUN scores are ~0, so HUN=9900 dominates trivially. If a future change adopts option B (adds tier/HDR/audio groups), re-verify the actual sqp-1-2160p score-set integers against HUN=9900 BEFORE applying — a top non-HUN combo (Tier 01 + DV + ATMOS + ...) could approach or exceed 9900 under that score set.
+   These three inequalities are the constraints any future HUN adjustment must satisfy.
 
-### The decisive Profilarr constraint for this repo
+8. NAMING-CONVENTION PRINCIPLE: Plex + Jellyfin + Emby friendly (the community-standard TRaSH/onedr0p scheme). The folder convention MUST match the existing library: {Title} (Year) for movie/series folders, Season 0X for season folders. Setting `media_naming` does NOT auto-rename existing files — it governs new downloads + manual Organize only, so the existing huge library is safe; renaming existing files is a separate, opt-in, selective step.
 
-- [observation] **Arr instances cannot be declared as code.** API v1 exposes `GET /arr` only
-  (and never returns the key) — there is **no POST/PATCH/DELETE for Arr instances**. URL +
-  API key must be typed into the UI and are then stored in `arr_instances.api_key` as
-  **plaintext in SQLite**, deliberately ("encrypting secrets at rest would be theatre …
-  the filesystem is the trust boundary"). Linked *databases* are fully API-manageable
-  (`POST /databases`, `POST /databases/{id}/sync`), profiles are not.
-- This collides with the repo non-negotiable that app-level secrets arrive via External
-  Secrets: the Arr API keys would live in a PVC instead, and that PVC is VolSync/Kopia
-  backed to OVH S3 (encrypted in transit/at rest by Kopia, so the backup leg is
-  acceptable — the in-cluster plaintext is the part that is new). The same DB also holds
-  GitHub PATs and TMDB/AI keys if those features are used. Only Profilarr's *own* OIDC
-  client secret could come from ESO.
+9. media_management PRINCIPLES: PROPER/REPACK only if genuinely better (doNotPrefer — not upgraded merely for being newer); upgrades are WANTED (auto_unmonitor_previous_downloads = false, so cutoff upgrades keep running); monitor everything (all for Sonarr, movieOnly for Radarr); recycle bin OFF; hardlinks ON for storage efficiency when qBittorrent and the arr share a filesystem. (Implementation note 2026-08-17: the recyclarr v8 media_management schema exposes ONLY propers_and_repacks — the other fields are not syncable via recyclarr and remain UI/manual settings; use_hardlinks on NFS is protocol/client-dependent and NOT guaranteed — runtime-verify on the mount; if it fails the arr falls back to copy (double storage during seeding). See docs/progress/arr-config-sync.)
 
-## Head-to-head
+10. DECLARATIVE / GitOps PRINCIPLE: recyclarr (YAML-in-git CronJob) is the single config-sync owner (Profilarr was evaluated and rejected per the roadmap). Config is Git-versioned and PVC-loss-safe (re-synced from git). The first real `recyclarr sync` MUST be preceded by a VolSync snapshot of both the radarr and sonarr PVCs, because delete_old_custom_formats + new profile/score writes rewrite live state.
 
-| Axis | Recyclarr | Profilarr |
-|---|---|---|
-| GitOps fit | **Full** — desired state is YAML in this repo | **Partial** — dataset is a git repo, but instances/credentials are UI-only |
-| Cluster footprint | 1 CronJob, runs seconds/day | 2 always-on containers + PVC + VolSync + HTTPRoute + OIDC gate + Pocket ID client |
-| Secret delivery | ESO → env var (`!env_var`) or mounted file (`!file`) | Typed into the UI, plaintext in SQLite; ESO only for its own OIDC secret |
-| Upstream source | TRaSH Guides **directly** | Dictionarry DB; TRaSH only via the `trash-pcd` conversion repo |
-| Authoring/testing | none | regex tests, CF testing vs releases, profile simulation |
-| Beyond profiles | none | upgrade searches, bulk rename, drift reports, delay profiles, notifications |
-| Scheduling | one global schedule (CronJob) | per-instance/per-section cron + intervals |
-| Rollback | revert the YAML commit, re-run | none (no diff tracking) |
-| Maturity | v8.7.0, steady cadence, MIT | v2.0.9 (2026-06-24), **no stable release since**, `develop` commits daily, AGPL-3.0 |
-| UID fit (10001) | native (rootless by design) | documented for 1000; arbitrary UID unverified |
-| Renovate | no group entry needed (bjw-s `repository`/`tag` picked up by the `helm-values` manager) | needs a `.renovate/groups.json5` entry — app + parser release in lockstep |
-| Attack surface | no listening port, no UI, no route | HTTP UI + REST API on the internal gateway, plaintext credential store |
+11. SCOPE DISCIPLINE: only the recyclarr config + callee CiliumNetworkPolicies; shared secret/store names and wiring are untouched; NO commit/push/PR until final human approval — implementation stays uncommitted in the working tree.
 
-## The mutual-exclusion constraint
+## Implementation — current state (2026-08-17, spec rewrite, uncommitted)
 
-- [observation] Both tools reconcile **the same objects by name** into the same instances.
-  Running them together means two competing writers: Recyclarr re-applies its YAML, and
-  Profilarr's `arr.drift` + `arr.sync.*` jobs detect that as drift and re-apply the PCD
-  state. Whichever ran last wins, forever. There is therefore **one config-sync owner per
-  Arr instance** — the only safe coexistence is Profilarr with all `arr.sync.*` schedules
-  disabled, used purely as an offline authoring/testing lab.
+Branch `feat/arr-config-sync`. Files: `recyclarr.yml` (Sonarr + Radarr blocks), `settings.yml` + `config/custom-formats/{radarr,sonarr}/hungarian.json` (local HUN CF), `externalsecret.yaml` (1PW → `recyclarr-secret`), `helmrelease.yaml` (app-template CronJob, digest-pinned recyclarr 8.7.1, @daily, hardened UID-10001), `kustomization.yaml` (configMapGenerator + Flux substitution-disable annotation), `ks.yaml`, and callee-side CNP edits on sonarr + radarr (4th `fromEndpoints` block each).
 
-## Options
+**Radarr (movies):**
+- quality_definition.type: sqp-uhd; caps 2160p (WEBDL/WEBRip/Bluray)=300, 1080p (WEBDL/WEBRip)=150 MB/min. 720p uncapped (sqp-uhd has no 720p entry — the small fallback).
+- quality_profile: [SQP] SQP-1 (2160p) (trash_id 5128baeb2b081b72126bc8482b2a86a0); reset_unmatched_scores enabled; **min_format_score: 0** (option A — no tier CF groups; see framework 7c); upgrade allowed, **until_quality: WEB 2160p**, until_score: 20000.
+- custom_format_groups: Golden Rule UHD (ff204bbcecdd487d1cefcefdbf0c278d) + Unwanted Formats SQP (15b1cf0b6f1a1493856a4355907affee).
+- custom_formats: HUN (home-ops-hungarian-language) **+9900**; explicit LQ (90a6f9a284dff5103f6346090e6280c8) + LQ Release Title (e204b80c87be9497a8a6eaff48f72905) + BR-DISK (ed38b889b31be83fda192888e2286d83) **-10000** (SQP Unwanted group lacks these).
+- media_management: propers_and_repacks: do_not_prefer. media_naming: folder plex-imdb, movie {rename: true, standard: plex-imdb}.
 
-1. **Recyclarr only (recommended)** — smallest change that solves the stated problem, fully
-   declarative, no new listening surface, no new plaintext credential store, mature
-   upstream, native fit with the repo's UID/rootless/read-only posture. Loses the
-   authoring, testing and simulation features, which are conveniences rather than
-   drift-prevention.
-2. **Profilarr only** — richest feature set and the better *authoring* experience, but it
-   trades away declarative config for a UI-owned SQLite state, introduces a plaintext
-   credential store and an internal HTTP surface, depends on a single-owner conversion repo
-   for TRaSH content, and its v2 line is ~10 weeks old with no stable release in the last
-   ~6 weeks. Defensible if the regex/simulation workflow is the actual goal.
-3. **Recyclarr as owner + Profilarr as a non-syncing lab** — Recyclarr keeps the instances
-   in line; Profilarr runs with every `arr.sync.*` schedule off, used only to author and
-   test regexes/profiles, whose output is then hand-carried into `recyclarr.yml`. Highest
-   total footprint and a manual hand-off step; only worth it if the testing tooling proves
-   itself.
-4. **Defer both** — accept manual profile maintenance. The status quo; costs nothing and
-   loses nothing already working.
+**Sonarr (series):**
+- quality_definition.type: series; caps 2160p (WEBDL/WEBRip)=200, 1080p=100, 720p=50 MB/min.
+- quality_profile: WEB-2160p (Combined) (trash_id c4cadd6b35b95f62c3d47a408e53e2f7); reset_unmatched_scores enabled; upgrade allowed, until_quality: WEB 2160p, until_score: 20000; **qualities override re-enables WEB 720p** (Combined disables it) — ladder WEB 2160p > WEB 1080p > WEB 720p, each WEBRip + WEBDL.
+- custom_format_groups: Golden Rule UHD (e3f37512790f00d0e89e54fe5e790d1c) + Language Profiles (74aff4168620ed49dcc67e92b2c2a5b4) + Streaming HD/UHD boost (85fae4a2294965b75710ef2989c850eb) + Unwanted Formats (59c3af66780d08332fdc64e68297098f, includes LQ/BR-DISK).
+- custom_formats: HUN (home-ops-hungarian-language) **+9900**.
+- media_management: propers_and_repacks: do_not_prefer. media_naming: series plex-imdb, season default, episodes {rename: true, standard/daily/anime: default}.
 
-Recommendation: **Option 1 now**, with a **re-evaluation gate on Profilarr**: revisit when
-it (a) publishes the documented major tag, (b) resumes a stable release cadence, and
-(c) offers a declarative bootstrap path for Arr instances (write endpoints under `/arr`).
+**Hungarian CF:** local custom format, `LanguageSpecification` fields.value 22 (Hungarian language ID), required, NO score — the score (+9900) lives in `recyclarr.yml` `assign_scores_to` on each profile. Modeled on the German TRaSH preset structure (no Hungarian guide preset exists).
 
-## Open decisions
+**Validation:** yamlfmt + yamllint clean; JSON-schema validate against https://schemas.recyclarr.dev/v8/config-schema.json → 0 errors; recyclarr binary not installed locally (no live `recyclarr lint`/dry-run; field-by-field + TRaSH guide JSON verification substituted). NOT synced, uncommitted.
 
-- [needs-decision] Which candidate — Options 1–4 above.
-- [needs-decision] **Quality profiles to adopt.** Sonarr: WEB-1080p, WEB-2160p, or the
-  Combined variant? Radarr: HD Bluray + WEB, UHD Bluray + WEB, or both? Depends on display
-  and storage budget, so it is a human call, not a research question.
-- [needs-decision] **Custom-format scope**: guide-backed profiles + auto-synced CF groups
-  (least config), guide-backed profiles + explicit CF list (explicit control), or fully
-  custom profiles (most maintenance).
-- [needs-decision] **Which sections to sync**: media naming yes/no, media management
-  (propers/repacks) yes/no, quality definitions yes/no.
-- [needs-decision] **1Password layout for the Arr API keys**: two new items
-  (`sonarr-api-key`, `radarr-api-key`) with a single field each, versus two new properties
-  on one shared item consumed by explicit `data[].remoteRef.{key,property}` — the shape
-  already used by `kubernetes/components/gateway-oidc/externalsecret.yaml:20-23`
-  (item `pocket-id-clients`, property `${APP}_client_secret`). The latter matches the
-  established convention more closely.
-- [needs-decision] Schedule (daily is almost certainly enough) and whether a sync failure
-  should notify at all — Alertmanager/Pushover already exists, so a failed CronJob could
-  ride the existing `KubeJobFailed`-class rules instead of adding tool-native notifications.
-- [needs-research] Does Recyclarr need a persistent config dir at all here? Its state is the
-  cloned guide repo plus logs, both re-derivable, so an `emptyDir` may be enough — which
-  would drop the PVC, the VolSync component and the backup surface entirely (the original
-  note assumed a PVC + VolSync by analogy with the reference repos). Measure the clone cost
-  of one run before deciding.
-- [needs-research] If Profilarr is chosen: does `/config` work under UID 10001 with
-  `fsGroup: 10001`, or must the app get a UID-1000 exception? Also decide `AUTH=off` behind
-  the `gateway-oidc` component (repo-canonical, mirrors
-  `kubernetes/apps/media/suggestarr/app/helmrelease.yaml:41-42`) versus native `AUTH=oidc`
-  with its own Pocket ID client — and note that the gate would also sit in front of
-  `/api/`, so `X-Api-Key` access needs a route exception or must be given up.
+**Limitations / manual-UI settings (recyclarr v8 syncs ONLY propers_and_repacks from media_management):** monitor_new_items (all Sonarr / movieOnly Radarr), auto_unmonitor_previous_downloads=false (so cutoff upgrades keep running), recycle_bin=false, use_hardlinks (NFS — protocol/client-dependent and NOT guaranteed; runtime-verify on the mount; if it fails the arr falls back to copy = double storage during seeding), delete_empty_series_folders (Sonarr), enable_media_info. These are NOT GitOps-managed (lost on PVC rebuild). Buildarr evaluated-later for declarative arr-settings management.
 
-## Implementation sketch — Recyclarr path
+Full decision/rationale/deviation detail: `docs/progress/arr-config-sync` → "## Implementation decisions (2026-08-17)" and "## Correction decisions (2026-08-17, Maestro verify)".
 
-1. Decide the 1Password layout, create the properties, and read the two API keys out of the
-   live Sonarr/Radarr `config.xml` to seed them.
-2. Create `kubernetes/apps/downloads/recyclarr/` (**not** `media`): `ks.yaml`,
-   `app/kustomization.yaml`, `app/ocirepository.yaml`, `app/externalsecret.yaml`,
-   `app/helmrelease.yaml`, `app/ciliumnetworkpolicy.yaml`, `app/config/recyclarr.yml`.
-3. `app/kustomization.yaml`: `configMapGenerator` for `recyclarr.yml` with
-   `disableNameSuffixHash`, and the **Flux substitution-disable annotation** on the
-   ConfigMap — `!env_var` is Recyclarr's own interpolation syntax and would otherwise
-   collide with Flux `postBuild` substitution. (Precedent for the generator pattern:
-   `kubernetes/apps/media/plex-trakt-sync/app/kustomization.yaml:10-18`.)
-4. `app/helmrelease.yaml`: app-template via `chartRef` → OCIRepository, a single
-   `type: cronjob` controller (`concurrencyPolicy: Forbid`, `successfulJobsHistory: 1`,
-   `failedJobsHistory: 3`, all three probes disabled), image `ghcr.io/recyclarr/recyclarr:8`
-   digest-pinned, `command: ["recyclarr","sync"]`, `envFrom` the ExternalSecret, repo-standard
-   securityContext (UID/GID 10001, `readOnlyRootFilesystem`, caps dropped, `emptyDir` at
-   `/tmp`). Shape reference: the only CronJob precedent in the repo is paperless' sibling
-   `backup` controller, `kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml:178-213`
-   — a standalone CronJob-only app would be first-of-kind at app level.
-5. Labels: `egress.home.arpa/allow-world: "true"` for the GitHub clone of the guides (as
-   sonarr already does) and `ingress.home.arpa/none: "true"` — nothing consumes it. DNS is
-   covered cluster-wide by `kubernetes/apps/kube-system/cilium/netpols/allow-dns-egress.yaml:23`;
-   in-cluster egress to the two Arr services is covered by the baseline as long as the pod
-   does **not** take the `egress.home.arpa/custom-egress` opt-out.
-6. **Edit both callees' CNPs** — add a `fromEndpoints` entry for recyclarr in
-   `kubernetes/apps/downloads/sonarr/app/ciliumnetworkpolicy.yaml` and radarr's equivalent.
-7. `ks.yaml`: `dependsOn` external-secrets/onepassword-connect (plus democratic-csi only if
-   a PVC survives the `[needs-research]` item above), `postBuild.substitute: APP: recyclarr`,
-   `targetNamespace: downloads`. No `gateway-oidc` component and no HTTPRoute — there is no UI.
-8. Register the app in `kubernetes/apps/downloads/kustomization.yaml`.
-9. Validate with `flux build ks recyclarr --dry-run` (plus `kubeconform`/pre-commit), commit,
-   push, and verify the first Job's logs report the expected profile/CF changes.
+## Pending (human-gated)
 
-## Implementation sketch — Profilarr path (only if Option 2/3 is chosen)
+- commit → push → PR → first recyclarr sync.
+- BEFORE first sync: VolSync snapshot of the radarr + sonarr PVCs (delete_old_custom_formats + new profile/score writes rewrite live state).
+- Verify-post-sync: Radarr `until_quality: WEB 2160p` cutoff took effect; HUN +9900 on both profiles; local HUN CF detected on releases.
 
-1. Resolve the two `[needs-research]` items first (UID 10001 viability; gate vs native OIDC)
-   — both change the manifest shape.
-2. `kubernetes/apps/downloads/profilarr/`: OCIRepository + HelmRelease with **two
-   controllers/containers** (`profilarr` on 6868, `parser` on 5000), image and parser pinned
-   to full semver + digest (no major tag exists), `PARSER_HOST`/`PARSER_PORT`, `TZ`,
-   `ORIGIN: https://<sub>.${PUBLIC_DOMAIN}`, `emptyDir` at `/tmp`, probes on
-   `/api/v1/health` and `/health`.
-3. `/config` PVC via the shared VolSync component (`VOLSYNC_CLAIM` defaults to `${APP}`),
-   `APP_UID`/`APP_GID` set to whatever the UID decision lands on.
-4. Route on `envoy-internal` (inline `route:` in the HelmRelease — the repo has no
-   standalone `httproute.yaml` for app-template apps) plus the `gateway-oidc` component,
-   `APP_SUBDOMAIN` substitution, and a Pocket ID client registration in
-   `provision/pocket-id/clients.yaml` with `gate: envoy` and the appropriate group.
-   `mergeType: StrategicMerge` in the SecurityPolicy is mandatory — omitting it silently
-   drops the Gateway-level RFC1918 allowlist and the CrowdSec gate for that route
-   (`kubernetes/apps/networking/CLAUDE.md:35`).
-5. Labels: `ingress.home.arpa/allow-gateway-internal: "true"`, plus world egress (or narrow
-   `toFQDNs` under `custom-egress`) for the PCD git pulls and TMDB.
-6. **Edit both callees' CNPs** (same requirement as the Recyclarr path).
-7. Add a `.renovate/groups.json5` entry grouping the app and parser images (lockstep
-   releases), following the shape at `.renovate/groups.json5:98-105`.
-8. Bootstrap by hand in the UI: link `trash-pcd` and/or the Dictionarry database, add the two
-   Arr instances with their API keys, set `conflict_strategy`, then enable the sync schedules.
-   Record in this note that this step is deliberately non-declarative.
+## Risks still relevant
 
-## Risks & unknowns
-
-- [risk] **Both candidates start writing to live Arr instances.** First run should be against
-  a known-good state with a fresh VolSync snapshot of the sonarr/radarr PVCs in hand;
-  profile/CF changes are not trivially reversible from the Arr side.
-- [risk] Profilarr has **no diff tracking and no rollback**, and its v2 line broke hard from
-  v1 ("existing databases and configurations cannot be migrated"). A future v3 could do the
-  same to a hand-curated dataset.
-- [risk] Profilarr's TRaSH content flows through a single-owner conversion repo; if
-  `trash-pcd` goes stale, the TRaSH-equivalent profiles go stale silently.
-- [risk] The Arr API keys currently exist **only** inside each app's `/config/config.xml`.
-  Copying them into 1Password creates a second source that must be re-synced if a key is
-  ever regenerated in the UI.
-- [unknown] Whether Profilarr tolerates an arbitrary UID (≠1000) on `/config`.
-- [unknown] Whether a 2.1.0 stable is imminent — `develop` is active daily, but the bulletin
-  channel points at a bare commit sha rather than a version.
-- [unknown] Profilarr's official docs site could not be verified: `dictionarry.dev` redirects
-  to a client-rendered SPA and `/wiki/profilarr-setup` 404s at the v2 host. Every Profilarr
-  fact above comes from the repository source, the OpenAPI spec, the releases/registry APIs,
-  and public home-ops manifests — **not** from vendor documentation pages.
-- [risk] Recyclarr's `!env_var` interpolation vs Flux `postBuild` substitution is a real
-  collision, not a theoretical one; the substitution-disable annotation on the ConfigMap is
-  load-bearing.
-
-## Effort
-
-- **Recyclarr**: **M** — roughly half a day. One new app directory, one ConfigMap, one
-  ExternalSecret, two callee CNP edits, plus the profile-selection decisions (which are
-  taste, not engineering). Dominated by choosing profiles and by the first supervised run.
-- **Profilarr**: **L** — 1–2 days. Two-container HelmRelease, PVC + VolSync, route + OIDC
-  gate + Pocket ID client + Terraform apply, Renovate group, UID investigation, then a
-  manual UI bootstrap that cannot be captured in git.
+- First `recyclarr sync` rewrites live Arr state (profiles, CFs, scores) → not trivially reversible from the Arr side → VolSync snapshot first.
+- `!env_var` interpolation vs Flux `postBuild` substitution collision → the ConfigMap substitution-disable annotation is load-bearing.
+- Arr API keys copied from each app's `/config/config.xml` into 1Password → must be re-synced if a key is regenerated in the UI.
+- Option B (tier/HDR/audio CF groups) is a documented future enhancement → re-verify the actual sqp-1-2160p score-set integers against HUN=9900 BEFORE applying (framework point 7c); a top non-HUN combo could approach/exceed 9900.
 
 ## Related
 
-- relates_to [[k8s-workloads]] — the app shape, canonical patterns and the `downloads`/`media` split
-- relates_to [[external-secrets]] — new 1Password properties for the Arr API keys; the
-  `pocket-id-clients`-style `data[].remoteRef` shape
-- relates_to [[volsync-backup]] — needed by the Profilarr path; possibly droppable on the
-  Recyclarr path (see `[needs-research]`)
-- relates_to [[networking]] — the callee-side CiliumNetworkPolicy edits and the
-  `envoy-internal` route + `StrategicMerge` requirement
-- relates_to [[iam]] — only if Profilarr is chosen: `gateway-oidc` component versus native
-  `AUTH=oidc`, plus the Pocket ID client and group ACL
+- relates_to [[k8s-workloads]] — app shape, canonical patterns, downloads/media split
+- relates_to [[external-secrets]] — 1Password properties for the Arr API keys
+- relates_to [[networking]] — callee-side CiliumNetworkPolicy edits

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./prowlarr/ks.yaml
   - ./radarr/ks.yaml
   - ./sonarr/ks.yaml
+  - ./recyclarr/ks.yaml
   - ./bazarr/ks.yaml
   - ./subsyncarr/ks.yaml
   - ./seerr/ks.yaml

--- a/kubernetes/apps/downloads/radarr/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/downloads/radarr/app/ciliumnetworkpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
-# radarr (AD-023): envoy-internal ingress via the ingress-from-gateway-internal CCNP; this CNP admits the *arr named consumers (bazarr, prowlarr, seerr) on the API port.
+# radarr (AD-023): envoy-internal ingress via the ingress-from-gateway-internal CCNP; this CNP admits the *arr named consumers (bazarr, prowlarr, seerr, recyclarr) on the API port.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -22,6 +22,9 @@ spec:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: downloads
             app.kubernetes.io/name: seerr
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: recyclarr
       toPorts:
         - ports:
             - port: "7878"

--- a/kubernetes/apps/downloads/recyclarr/app/config/custom-formats/radarr/hungarian.json
+++ b/kubernetes/apps/downloads/recyclarr/app/config/custom-formats/radarr/hungarian.json
@@ -1,0 +1,15 @@
+{
+  "trash_id": "home-ops-hungarian-language",
+  "name": "Hungarian Language",
+  "specifications": [
+    {
+      "name": "Hungarian",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 22
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/downloads/recyclarr/app/config/custom-formats/sonarr/hungarian.json
+++ b/kubernetes/apps/downloads/recyclarr/app/config/custom-formats/sonarr/hungarian.json
@@ -1,0 +1,15 @@
+{
+  "trash_id": "home-ops-hungarian-language",
+  "name": "Hungarian Language",
+  "specifications": [
+    {
+      "name": "Hungarian",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 22
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+# recyclarr sync for Sonarr + Radarr — priority order HUN dub > quality > size
+# (see BM docs/progress/arr-config-sync for the full planning framework). Local Hungarian CF
+# is scored +9900 so a HUN 720p/1080p beats any non-HUN release; LQ/BR-DISK -10000; explicit
+# quality_definition max caps reject gigantic 4K/1080p encodes while 720p/1080p stay as fallback.
+sonarr:
+  series:
+    base_url: http://sonarr.downloads.svc.cluster.local:8989
+    api_key: !env_var SONARR_API_KEY
+    delete_old_custom_formats: true
+    media_management:
+      propers_and_repacks: do_not_prefer
+    media_naming:
+      episodes:
+        anime: default
+        daily: default
+        rename: true
+        standard: default
+      season: default
+      series: plex-imdb
+    quality_definition:
+      type: series
+      qualities:
+        - name: WEBDL-2160p
+          max: 200
+        - name: WEBRip-2160p
+          max: 200
+        - name: WEBDL-1080p
+          max: 100
+        - name: WEBRip-1080p
+          max: 100
+        - name: WEBDL-720p
+          max: 50
+        - name: WEBRip-720p
+          max: 50
+    quality_profiles:
+      - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7 # WEB-2160p (Combined)
+        reset_unmatched_scores:
+          enabled: true
+        upgrade:
+          allowed: true
+          until_quality: WEB 2160p
+          until_score: 20000
+        # Combined profile disables WEB 720p; re-enable it so content only available in 720p
+        # is still grabbed (HUN > quality > size — fallback must be preserved).
+        qualities:
+          - name: WEB 2160p
+            qualities:
+              - WEBRip-2160p
+              - WEBDL-2160p
+          - name: WEB 1080p
+            qualities:
+              - WEBRip-1080p
+              - WEBDL-1080p
+          - name: WEB 720p
+            qualities:
+              - WEBRip-720p
+              - WEBDL-720p
+    custom_format_groups:
+      add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c # [Optional] Golden Rule UHD
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
+        - trash_id: 85fae4a2294965b75710ef2989c850eb # [Streaming Services] HD/UHD boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f # [Unwanted] Unwanted Formats (LQ/BR-DISK incl.)
+    custom_formats:
+      - trash_ids:
+          - home-ops-hungarian-language
+        assign_scores_to:
+          - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+            score: 9900
+radarr:
+  movies:
+    base_url: http://radarr.downloads.svc.cluster.local:7878
+    api_key: !env_var RADARR_API_KEY
+    delete_old_custom_formats: true
+    media_management:
+      propers_and_repacks: do_not_prefer
+    media_naming:
+      folder: plex-imdb
+      movie:
+        rename: true
+        standard: plex-imdb
+    quality_definition:
+      type: sqp-uhd
+      # sqp-uhd (not sqp-streaming): no 720p entry keeps 720p uncapped as the fallback
+      # (sqp-streaming would cap 720p at 85.7 MB/min, rejecting large HUN 720p vs HUN > size).
+      # Cap allowed 2160p/1080p WEB+Bluray qualities to reject gigantic encodes.
+      qualities:
+        - name: WEBDL-2160p
+          max: 300
+        - name: WEBRip-2160p
+          max: 300
+        - name: Bluray-2160p
+          max: 300
+        - name: WEBDL-1080p
+          max: 150
+        - name: WEBRip-1080p
+          max: 150
+    quality_profiles:
+      - trash_id: 5128baeb2b081b72126bc8482b2a86a0 # [SQP] SQP-1 (2160p)
+        reset_unmatched_scores:
+          enabled: true
+        # Profile default minFormatScore=1000 would reject every non-HUN release (no tier CF
+        # groups are added); lower to 0 so 720p/1080p fallback works. LQ/BR-DISK (-10000) still
+        # reject junk; a HUN+LQ release (9900 + (-10000) = -100 < 0) is rejected, restoring the
+        # LQ-rejection invariant at no cost to fallback or HUN dominance.
+        min_format_score: 0
+        upgrade:
+          allowed: true
+          until_quality: WEB 2160p
+          until_score: 20000
+    custom_format_groups:
+      add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d # [Optional] Golden Rule UHD
+        - trash_id: 15b1cf0b6f1a1493856a4355907affee # [Unwanted] Unwanted Formats SQP
+    custom_formats:
+      - trash_ids:
+          - home-ops-hungarian-language
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
+            score: 9900
+      # SQP Unwanted group lacks LQ/BR-DISK; add them explicitly to preserve junk rejection.
+      - trash_ids:
+          - 90a6f9a284dff5103f6346090e6280c8 # LQ
+          - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+          - ed38b889b31be83fda192888e2286d83 # BR-DISK
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
+            score: -10000
+      # AV1 + 3D are trash-guide required-unwanted but not members of the SQP Unwanted group;
+      # add explicitly to complete the 'exclude BAD quality' coverage on SQP-1.
+      - trash_ids:
+          - cae4ca30163749b891686f95532519bd # AV1
+          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
+            score: -10000

--- a/kubernetes/apps/downloads/recyclarr/app/config/settings.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/settings.yml
@@ -1,0 +1,12 @@
+---
+# Local custom-format resource providers (recyclarr v8): loads the Hungarian
+# language CF from the per-service folders below so it can be scored in recyclarr.yml.
+resource_providers:
+  - name: hungarian-cfs-sonarr
+    type: custom-formats
+    path: /config/custom-formats/sonarr
+    service: sonarr
+  - name: hungarian-cfs-radarr
+    type: custom-formats
+    path: /config/custom-formats/radarr
+    service: radarr

--- a/kubernetes/apps/downloads/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recyclarr
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: recyclarr-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: radarr
+        property: radarr_api_key
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: sonarr
+        property: sonarr_api_key

--- a/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: recyclarr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      recyclarr:
+        type: cronjob
+        cronjob:
+          schedule: "@daily"
+          backoffLimit: 0
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 1
+          successfulJobsHistory: 0
+        containers:
+          app:
+            image:
+              repository: ghcr.io/recyclarr/recyclarr
+              tag: 8.7.1@sha256:73303ba5ee647b6492fee917d3a781c6e59b6cab08f9dfce9482a950846f564f
+            args:
+              - sync
+            env:
+              RECYCLARR_DATA_DIR: /tmp
+              SONARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: recyclarr-secret
+                    key: SONARR_API_KEY
+              RADARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: recyclarr-secret
+                    key: RADARR_API_KEY
+            resources:
+              requests:
+                cpu: 5m
+                memory: 36Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              privileged: false
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        existingClaim: recyclarr
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir
+      config-files:
+        type: configMap
+        name: recyclarr-config
+        globalMounts:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+          - path: /config/settings.yml
+            subPath: settings.yml
+          - path: /config/custom-formats/sonarr/hungarian.json
+            subPath: sonarr-hungarian.json
+          - path: /config/custom-formats/radarr/hungarian.json
+            subPath: radarr-hungarian.json

--- a/kubernetes/apps/downloads/recyclarr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/recyclarr/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: recyclarr-config
+    files:
+      - recyclarr.yml=config/recyclarr.yml
+      - settings.yml=config/settings.yml
+      - sonarr-hungarian.json=config/custom-formats/sonarr/hungarian.json
+      - radarr-hungarian.json=config/custom-formats/radarr/hungarian.json

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: recyclarr
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: recyclarr
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: democratic-csi
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/downloads/recyclarr/app
+  postBuild:
+    substitute:
+      APP: recyclarr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: downloads
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/downloads/sonarr/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/ciliumnetworkpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
-# sonarr (AD-023): envoy-internal ingress via the ingress-from-gateway-internal CCNP; this CNP admits the *arr named consumers (bazarr, prowlarr, seerr) on the API port.
+# sonarr (AD-023): envoy-internal ingress via the ingress-from-gateway-internal CCNP; this CNP admits the *arr named consumers (bazarr, prowlarr, seerr, recyclarr) on the API port.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -22,6 +22,9 @@ spec:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: downloads
             app.kubernetes.io/name: seerr
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: recyclarr
       toPorts:
         - ports:
             - port: "8989"


### PR DESCRIPTION
## Summary

Adds **recyclarr** as a Flux CronJob under `kubernetes/apps/downloads/recyclarr/` to declaratively sync Sonarr/Radarr quality profiles, custom formats, quality definitions, and naming from the TRaSH Guides into the live `downloads` *arr instances on a daily schedule.

- **Engine**: recyclarr CronJob (app-template, digest-pinned 8.7.1, hardened UID 10001, `@daily`, VolSync-backed `/config` PVC).
- **Priority order**: `HUN > quality > size` — a local Hungarian-dub custom format (`LanguageSpecification` value 22) is scored **+9900** on both profiles so a Hungarian 720p/1080p beats any non-HUN 4K, while within-HUN the profile quality order (4K > 1080p > 720p) still ranks. `min_format_score: 0` + `until_score: 20000` keep 720p/1080p fallback and within-HUN upgrades; the +9900 (not +10000) preserves the LQ-rejection invariant (HUN 9900 + LQ -10000 = -100 < 0).
- **Profiles**: Radarr SQP-1 (2160p) on the `sqp-uhd` size set; Sonarr WEB-2160p (Combined) with a `qualities` override re-enabling WEB 720p fallback. Both upgrade to WEB 2160p.
- **Size caps**: explicit `quality_definition.qualities[].max` overrides (Radarr 2160p=300/1080p=150 MB/min; Sonarr 2160p=200/1080p=100/720p=50) reject bloated 4K/1080p encodes — the TRaSH default max (2000) is non-binding. 720p left uncapped on Radarr (the small fallback).
- **Bad-quality exclusion**: Golden Rule UHD (x265 no-HDR/DV -10000) + Unwanted groups; AV1/3D/LQ/LQ-Release-Title/BR-DISK added explicitly at -10000 where the SQP Unwanted group lacks them.
- **Secrets**: Arr API keys ESO-delivered from 1Password (`recyclarr-secret`); no plaintext credentials in-repo.
- **Network**: callee-side CiliumNetworkPolicy edits on radarr (7878) + sonarr (8989) admit recyclarr; no recyclarr egress CNP needed (default-allow).

## Review verdict

Best-practice review against the TRaSH Guides (Radarr + Sonarr profile/file-size/german-en pages) and the recyclarr v8 schema. **Sonarr: full coverage** of the "exclude BAD quality" goal (Unwanted group natively carries AV1/LQ/LQ-RT/BR-DISK/Upscaled). **Radarr: covered** after this PR's explicit AV1+3D add — the SQP Unwanted group lacks AV1/3D/LQ/BR-DISK, so all four are added explicitly at -10000. HDR/DV boost CFs intentionally omitted (option A) to keep non-HUN scores ~0 and HUN dominance trivial; adding them later (option B) requires re-verifying HUN=9900 against the sqp-1-2160p score-set. Quality-definition `min` floors omitted; fake/upscaled 4K relies on the Upscaled CF (-10000).

Open verify-gates (post-merge, manual): (1) confirm 1Password items `radarr`/`sonarr` hold current live API keys; (2) confirm Radarr `until_quality: WEB 2160p` suppresses Bluray-2160p grabs; (3) recyclarr does not attempt to write the read-only ConfigMap-mounted `settings.yml`.

## Transition plan

1. **Pre-merge**: VolSync snapshots of the radarr + sonarr PVCs taken (rollback point) — done in this PR's prep.
2. **Merge** → Flux reconciles → recyclarr CronJob deployed + ExternalSecret synced.
3. **First sync**: triggered manually (post-merge) once the CronJob is live; rewrites the *arr quality profiles/CFs/quality-defs via API.
4. **Post-sync verify**: read back live profiles via the *arr UI (HUN +9900, cutoff WEB 2160p, unwanted -10000); then remap the existing library naming and delete the old (sub-optimal) profiles in the UI.
5. **Rollback**: if the first sync goes wrong, restore radarr/sonarr PVCs from the pre-merge VolSync snapshots (`just volsync restore …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)