### PR TITLE
fix(recyclarr): set quality preferred <= max and target SQP-1 for Golden Rule UHD

### DIFF
--- a/basic-memory/docs/progress/arr-config-sync.md
+++ b/basic-memory/docs/progress/arr-config-sync.md
@@ -244,3 +244,37 @@ Commit `b6a36eff0` on branch `fix/recyclarr-egress`: `🐛 fix(recyclarr): add a
 - Post-merge: recyclarr CronJob re-deploys with the label; re-trigger first sync manually.
 - Post-sync verify: TRaSH-Guides repo clones; quality profiles/CFs/quality-defs written to the live *arr; read back HUN +9900 / cutoff WEB 2160p / unwanted -10000.
 - Rollback path unchanged: pre-merge VolSync snapshots (radarr `cfad81…`, sonarr `9c4a4f…`) from the prior session.
+
+
+## Session 2026-08-17 — FIX-2: quality preferred + Golden Rule UHD targeting
+
+After the egress fix (#4195 merged) the Maestro triggered the first live recyclarr sync. It reached github.com (egress OK) but the job FAILED (exit non-zero) on **three config defects**. Live radarr/sonarr pods stayed healthy; apply state was partial/unknown. A corrected re-sync is idempotent and converges, so the fix is config-then-re-sync (no rollback needed).
+
+### Defect 1 — Radarr quality_definition validation error
+`ERR 'Quality WEBDL-1080p: preferred (1999) cannot be greater than max (150)'`. The `type: sqp-uhd` size-set carries default `preferred` values; our override set only `max`, leaving the size-set preferred (1999) which exceeds our max (150). recyclarr validates `preferred <= max`.
+
+### Defect 2 — Sonarr quality_definition validation error
+`ERR 'Quality WEBRip-720p: preferred (995) cannot be greater than max (50)'` — same root cause on the `type: series` size-set.
+
+### Defect 3 — Radarr Golden Rule UHD CF group skipped (WRN)
+`[Optional] Golden Rule UHD (ff204b…) was skipped because none of your quality profiles are in its compatibility list.` SQP-1 is NOT in Golden Rule UHD's compat list, so the group's default score-set (x265-no-HDR/DV -10000) was never applied to SQP-1. (Sonarr Golden Rule UHD did NOT skip — it applied via compat with WEB-2160p Combined; Sonarr left unchanged.)
+
+### Fixes (one file: recyclarr.yml)
+1. **preferred on every capped quality** (~60% of max, rounded, <= max): Radarr 2160p/Bluray-2160p=180, 1080p=90; Sonarr 2160p=120, 1080p=60, 720p=30. Future-proofs against size-set default drift and satisfies recyclarr validation. No `min` floors added (human decision: rely on the Upscaled CF for fake/upscaled 4K).
+2. **Golden Rule UHD forced onto SQP-1**: changed the Radarr `custom_format_groups.add` Golden Rule UHD entry from a bare `trash_id` to include `assign_scores_to` targeting SQP-1 (`5128baeb…`). The group's default score-set now applies x265(no HDR/DV) -10000 to SQP-1. The Unwanted SQP entry is left as a bare `trash_id`.
+
+### Indent correction (flagged vs. brief)
+The brief stated `assign_scores_to` at 8-space / child `trash_id` at 10-space — that is the `custom_formats` indent, but `custom_format_groups.add` nests one level deeper (the extra `add:` key), so the syntactically-correct indent is 10-space for `assign_scores_to` (sibling of the group item's `trash_id`) and 12-space for the child `- trash_id:`. Used 10/12; yamllint clean confirms valid YAML.
+
+### Validation
+- read-back: all preferred values present and <= max; assign_scores_to block targets SQP-1 ✓
+- `yamlfmt --dry --conf .yamlfmt.yaml` → 'No files will be changed' (exit 0) ✓
+- `yamllint -c .yamllint.yaml` → clean (exit 0) ✓
+
+Commit `935a73cc9` on branch `fix/recyclarr-quality-def-cf`: `🐛 fix(recyclarr): set quality preferred <= max and target SQP-1 for Golden Rule UHD`. PR opened against `main`. Re-sync pending — **Maestro merges the fix then re-triggers the sync** (worker does not merge, does not trigger sync).
+
+### Next
+- Wait for Maestro merge (after green CI).
+- Post-merge: recyclarr re-sync should pass validation (preferred <= max) and apply Golden Rule UHD to SQP-1.
+- Post-sync verify: live *arr quality_definition preferred values match; SQP-1 carries x265(no HDR/DV) -10000; HUN +9900 / cutoff WEB 2160p / unwanted -10000 intact.
+- Rollback path unchanged: pre-merge VolSync snapshots (radarr `cfad81…`, sonarr `9c4a4f…`) from PR #4193's prep.

--- a/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
@@ -21,19 +21,27 @@ sonarr:
       series: plex-imdb
     quality_definition:
       type: series
+      # preferred = balanced ~60% of max (<= max): satisfies recyclarr validation (preferred must
+      # not exceed max) and nudges toward balanced-size releases within the bloat cap; tunable.
       qualities:
         - name: WEBDL-2160p
           max: 200
+          preferred: 120
         - name: WEBRip-2160p
           max: 200
+          preferred: 120
         - name: WEBDL-1080p
           max: 100
+          preferred: 60
         - name: WEBRip-1080p
           max: 100
+          preferred: 60
         - name: WEBDL-720p
           max: 50
+          preferred: 30
         - name: WEBRip-720p
           max: 50
+          preferred: 30
     quality_profiles:
       - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7 # WEB-2160p (Combined)
         reset_unmatched_scores:
@@ -86,17 +94,24 @@ radarr:
       # sqp-uhd (not sqp-streaming): no 720p entry keeps 720p uncapped as the fallback
       # (sqp-streaming would cap 720p at 85.7 MB/min, rejecting large HUN 720p vs HUN > size).
       # Cap allowed 2160p/1080p WEB+Bluray qualities to reject gigantic encodes.
+      # preferred = balanced ~60% of max (<= max): satisfies recyclarr validation and favors
+      # balanced size within the bloat cap; tunable. No min floors (Upscaled CF covers fakes).
       qualities:
         - name: WEBDL-2160p
           max: 300
+          preferred: 180
         - name: WEBRip-2160p
           max: 300
+          preferred: 180
         - name: Bluray-2160p
           max: 300
+          preferred: 180
         - name: WEBDL-1080p
           max: 150
+          preferred: 90
         - name: WEBRip-1080p
           max: 150
+          preferred: 90
     quality_profiles:
       - trash_id: 5128baeb2b081b72126bc8482b2a86a0 # [SQP] SQP-1 (2160p)
         reset_unmatched_scores:
@@ -113,6 +128,8 @@ radarr:
     custom_format_groups:
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d # [Optional] Golden Rule UHD
+          assign_scores_to:
+            - trash_id: 5128baeb2b081b72126bc8482b2a86a0
         - trash_id: 15b1cf0b6f1a1493856a4355907affee # [Unwanted] Unwanted Formats SQP
     custom_formats:
       - trash_ids:


### PR DESCRIPTION
## Context

After the egress fix (#4195 merged), the first live recyclarr sync reached github.com (egress OK) but the job FAILED (exit non-zero) on three config defects. Live radarr/sonarr pods stayed healthy; apply state was partial/unknown. A corrected re-sync is idempotent and converges, so the fix is config-then-re-sync (no rollback).

## The 3 defects (from the sync log)

1. **Radarr quality_definition validation**: `ERR 'Quality WEBDL-1080p: preferred (1999) cannot be greater than max (150)'`. The `type: sqp-uhd` size-set carries default `preferred` values; our override set only `max`, leaving the size-set `preferred` (1999) which exceeds our `max` (150). recyclarr validates `preferred <= max`.
2. **Sonarr quality_definition validation**: `ERR 'Quality WEBRip-720p: preferred (995) cannot be greater than max (50)'` — same root cause on the `type: series` size-set.
3. **Radarr Golden Rule UHD CF group skipped (WRN)**: `[Optional] Golden Rule UHD (ff204b…) was skipped because none of your quality profiles are in its compatibility list.` SQP-1 is not in Golden Rule UHD's compat list, so the group's default score-set (x265-no-HDR/DV -10000) was never applied to SQP-1. (Sonarr Golden Rule UHD did NOT skip — it applied via compat with WEB-2160p Combined; Sonarr is left unchanged.)

## Fixes (one file: `recyclarr.yml`)

1. **`preferred` on every capped quality** (~60% of max, rounded, ≤ max), so the explicit preferred overrides the size-set default and satisfies recyclarr validation:
   - Radarr: WEBDL-2160p/WEBRip-2160p/Bluray-2160p `preferred: 180` (max 300); WEBDL-1080p/WEBRip-1080p `preferred: 90` (max 150).
   - Sonarr: WEBDL-2160p/WEBRip-2160p `preferred: 120` (max 200); WEBDL-1080p/WEBRip-1080p `preferred: 60` (max 100); WEBDL-720p/WEBRip-720p `preferred: 30` (max 50).
   - No `min` floors added (human decision: rely on the Upscaled CF for fake/upscaled 4K).
2. **Golden Rule UHD forced onto SQP-1**: the Radarr `custom_format_groups.add` Golden Rule UHD entry now carries `assign_scores_to` targeting SQP-1 (`5128baeb…`), so the group's default score-set applies x265(no HDR/DV) -10000 to SQP-1. The Unwanted SQP entry is left as a bare `trash_id`. Sonarr's `custom_format_groups` is untouched.

> Note on indent: `custom_format_groups.add` nests one level deeper than `custom_formats` (the extra `add:` key), so `assign_scores_to` is at 10-space (sibling of the group item's `trash_id`) and its child `- trash_id:` at 12-space — valid YAML, yamllint clean.

## Validation

- read-back: all `preferred` values present and ≤ max; `assign_scores_to` block targets SQP-1 ✓
- `yamlfmt --dry --conf .yamlfmt.yaml` → "No files will be changed" (exit 0) ✓
- `yamllint -c .yamllint.yaml` → clean (exit 0) ✓

## Re-sync pending

After merge, the Maestro re-triggers the recyclarr sync; it should pass validation (`preferred <= max`) and apply Golden Rule UHD to SQP-1. Rollback path (if anything goes wrong) is unchanged: the pre-merge VolSync snapshots of radarr/sonarr from PR #4193's prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)