### PR TITLE
✨ feat(jellyfin): add jellyfin 10.11.11 media server with introskipper support

### DIFF
--- a/basic-memory/docs/progress/jellyfin.md
+++ b/basic-memory/docs/progress/jellyfin.md
@@ -9,7 +9,7 @@ permalink: home-ops/docs/progress/jellyfin
 ## Metadata (observation-form)
 
 - [type] progress-note
-- [topic] Jellyfin 12.0-rc5 media server alongside plex in the media namespace, with Introskipper support
+- [topic] Jellyfin 10.11.11 media server alongside plex in the media namespace, with Introskipper support
 - [status] IN PROGRESS — manifests written, rendered and linted locally; NOT yet deployed (PR open, awaiting merge + Flux reconcile)
 - [branch] feat/jellyfin
 - [area] k8s-workloads, networking, volsync-backup
@@ -20,7 +20,7 @@ permalink: home-ops/docs/progress/jellyfin
 
 ## Decisions (with the human, 2026-08-20)
 
-- [decision] **Image**: `ghcr.io/jellyfin/jellyfin:12.0-rc5@sha256:669d234c776a37b331d875f58246434f80dbbbb619fa7edef55ce26d187baa2c` — explicitly requested pre-release (Jellyfin 12 RC). Digest resolved from the ghcr manifest list. Renovate needs no extra config: every `automerge` rule in `.renovate/autoMerge.json5` is `false`, so an rc6 bump arrives as a reviewable PR.
+- [decision] **Image**: `ghcr.io/jellyfin/jellyfin:10.11.11@sha256:45f648c382a0c8b552582fcea40e95cb17c5d475473a891cba0eb7523fb92112` — **REVISED 2026-08-21.** The first round pinned the explicitly requested pre-release `12.0-rc5@sha256:669d234c…`; the human then switched to the stable 10.11.11, which is byte-identical to the tag+digest the bjw-s reference pins. Note `v10.11.11` does NOT exist in the registry — the tag carries no `v` prefix. Side effects of the switch: Introskipper now runs on its **stable 10.11 track** (`10.11/v1.10.11.22`) instead of the `12.0` pre-release track, and its documented system requirement is literally "Jellyfin 10.11.11 (or newer)" — an exact match. Renovate needs no extra config: every `automerge` rule in `.renovate/autoMerge.json5` is `false`, so both 10.11.x patches and a future 12.x major arrive as reviewable PRs.
 - [decision] **Exposure**: `envoy-internal` HTTPRoute ONLY (`jellyfin.${PUBLIC_DOMAIN}`), **no LoadBalancer service**. Deliberately different from both the reference (which adds an LB IP) and plex (LB-only, no route). No `JELLYFIN_IP` cluster-setting was added.
 - [decision] **No OIDC gate**: `components/gateway-oidc` deliberately NOT attached — the Envoy OIDC redirect breaks native Jellyfin clients (Android TV, iOS). Jellyfin's own auth is the boundary; acceptable because the route is internal-only.
 - [decision] **GPU**: the node advertises exactly ONE `gpu.intel.com` device (`0000-00-02-0-0x9bc5`, `allowMultipleAllocations: None`), and plex's DRA claim held it. Human chose to **hand the iGPU to jellyfin**; plex loses hardware transcode. The alternative (one shared `ResourceClaim` in the `media` namespace referenced by both pods via `resourceClaimName`, which DRA's `reservedFor` permits) was surfaced and not taken.
@@ -53,10 +53,10 @@ Mounts that differ from the reference by intent:
 - [verified] `yamllint` + `yamlfmt -lint` clean on all new/touched files
 - [verified] `pre-commit run --files …` — all applicable hooks Passed (gitleaks, yamlfmt, yamllint, secret check)
 - [verified] `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster` → **134 passed** (0 failed). Note: must run with `dangerouslyDisableSandbox` — inside the Bash sandbox every `helm template` OCI pull fails with the known Go TLS error `x509: OSStatus -26276`, which is environmental and unrelated to the change.
-- [verified] Rendered Deployment carries `resourceClaims: [{name: gpu, resourceClaimTemplateName: jellyfin-gpu}]`, `resources.claims: [{name: gpu}]`, all six volumeMounts (`/cache`, `/config`, `/metadata`, `/config/data/introskipper`, `/media`, `/tmp`), and the two CCNP labels
+- [verified] Rendered Deployment carries `resourceClaims: [{name: gpu, resourceClaimTemplateName: jellyfin-gpu}]`, `resources.claims: [{name: gpu}]`, all six volumeMounts (`/cache`, `/config`, `/metadata`, `/config/data/introskipper`, `/media`, `/tmp`), and the two CCNP labels. The 10.11.11 image config exposes the same `JELLYFIN_DATA_DIR=/config` / `JELLYFIN_CACHE_DIR=/cache` layout as 12.0-rc5, so the mount design is unaffected by the version switch.
 - [verified] Rendered `ResourceClaimTemplate jellyfin-gpu` exists; `plex-gpu` is gone from the build output and the plex Deployment has no GPU claim
 - [verified] Rendered HTTPRoute: single `envoy-internal/https` parentRef, hostname `jellyfin.horvathzoltan.me`, Homepage annotations (group `Media`, icon `jellyfin.svg`)
-- [verified] Introskipper supports Jellyfin 12 — the upstream repo ships a dedicated `12.0/v1.12.0.1` release track next to `10.11`; manifest URL `https://intro-skipper.org/manifest.json` is version-aware and returns the right build per server version
+- [verified] Introskipper supports our version — the upstream repo ships parallel `10.11` and `12.0` release tracks (`10.11/v1.10.11.22` is current on the stable track we now target, and its stated requirement is Jellyfin 10.11.11+); manifest URL `https://intro-skipper.org/manifest.json` is version-aware and returns the right build per server version, so the URL is the same either way
 - [not verified] Nothing is deployed. Live behavior (pod scheduling with the freed GPU, VAAPI/QSV transcode, plugin install, NFS library scan) is post-merge work.
 
 ## Post-deploy manual steps (Jellyfin UI, after Flux reconciles)
@@ -74,7 +74,7 @@ Mounts that differ from the reference by intent:
 - [task] Any in-cluster consumer of jellyfin needs a per-app CNP admitting it on 8096, because the baseline is ingress default-deny and jellyfin has no CNP today. Two concrete cases: (a) `seerr` if it should drive jellyfin instead of plex; (b) `sonarr`/`radarr`/`bazarr` library-refresh notifications (Connect → Emby/Jellyfin) — the reference's own CNP admits exactly `bazarr`, `sonarr`, `radarr`, `maintainerr` plus two apps we do not run (`mumc`, `jellyplex-watched`).
 - [task] Update BM `docs/areas/k8s-workloads` after deployment: media namespace grows to 5 apps, and the "Plex GPU wiring" component claim becomes a jellyfin claim.
 - [task] Sizing is estimated from plex, not measured — revisit `requests.memory: 512Mi` / `limits.memory: 4Gi` and the 10Gi metadata PVC once the library is scanned.
-- [task] 12.0-rc5 is a pre-release. Watch for plugin ABI churn on rc bumps; Renovate PRs are review-gated, not auto-merged.
+- [task] ~~12.0-rc5 pre-release risk~~ — dropped, we ship stable 10.11.11. A future 12.x major bump will need an Introskipper track change (`10.11` → `12.0` plugin build) and a plugin-ABI check; Renovate PRs are review-gated, not auto-merged.
 
 ## Reference diff — full field-by-field audit (2026-08-21)
 

--- a/basic-memory/docs/progress/jellyfin.md
+++ b/basic-memory/docs/progress/jellyfin.md
@@ -1,0 +1,77 @@
+---
+title: jellyfin
+type: note
+permalink: home-ops/docs/progress/jellyfin
+---
+
+# jellyfin — execution progress
+
+## Metadata (observation-form)
+
+- [type] progress-note
+- [topic] Jellyfin 12.0-rc5 media server alongside plex in the media namespace, with Introskipper support
+- [status] IN PROGRESS — manifests written, rendered and linted locally; NOT yet deployed (PR open, awaiting merge + Flux reconcile)
+- [branch] feat/jellyfin
+- [area] k8s-workloads, networking, volsync-backup
+- [created] 2026-08-20
+- [reference] bjw-s-labs/home-ops kubernetes/apps/media/jellyfin (helmrelease.yaml + ks.yaml)
+- [relates_to] [[k8s-workloads]]
+- [relates_to] [[networking]]
+
+## Decisions (with the human, 2026-08-20)
+
+- [decision] **Image**: `ghcr.io/jellyfin/jellyfin:12.0-rc5@sha256:669d234c776a37b331d875f58246434f80dbbbb619fa7edef55ce26d187baa2c` — explicitly requested pre-release (Jellyfin 12 RC). Digest resolved from the ghcr manifest list. Renovate needs no extra config: every `automerge` rule in `.renovate/autoMerge.json5` is `false`, so an rc6 bump arrives as a reviewable PR.
+- [decision] **Exposure**: `envoy-internal` HTTPRoute ONLY (`jellyfin.${PUBLIC_DOMAIN}`), **no LoadBalancer service**. Deliberately different from both the reference (which adds an LB IP) and plex (LB-only, no route). No `JELLYFIN_IP` cluster-setting was added.
+- [decision] **No OIDC gate**: `components/gateway-oidc` deliberately NOT attached — the Envoy OIDC redirect breaks native Jellyfin clients (Android TV, iOS). Jellyfin's own auth is the boundary; acceptable because the route is internal-only.
+- [decision] **GPU**: the node advertises exactly ONE `gpu.intel.com` device (`0000-00-02-0-0x9bc5`, `allowMultipleAllocations: None`), and plex's DRA claim held it. Human chose to **hand the iGPU to jellyfin**; plex loses hardware transcode. The alternative (one shared `ResourceClaim` in the `media` namespace referenced by both pods via `resourceClaimName`, which DRA's `reservedFor` permits) was surfaced and not taken.
+- [decision] **Egress deviation from the discussed FQDN allowlist**: implemented as `egress.home.arpa/allow-world: "true"` (the `allow-world-egress` CCNP), NOT a per-app `toFQDNs` CNP. Rationale: a media server needs metadata providers (TMDB/TVDB image CDNs) on top of the plugin catalog, and every close sibling in the same class (plex, sonarr, radarr) uses `allow-world`. An FQDN allowlist would be a fragile, high-maintenance list. Consequence: no per-app `ciliumnetworkpolicy.yaml` exists for jellyfin at all — ingress is the `ingress-from-gateway-internal` CCNP, egress the `allow-world-egress` CCNP.
+- [decision] **Storage split**: config PVC (`jellyfin`, 5Gi, VolSync-backed) + separate `jellyfin-metadata` PVC (10Gi, deliberately NOT backed up) carrying `/metadata` (library artwork) and `/config/data/introskipper` (fingerprint DB). Mirrors the plex `plex` + `plex-rebuildable` split and the reference's metadata PVC.
+- [decision] **Introskipper**: plugin installation is unavoidably a manual UI step (there is no GitOps plugin installer). GitOps prepares the mount + the internet egress; the human installs from the plugin catalog. Human also chose to include the **File Transformation** plugin (optional web-UI enhancements).
+
+## What was implemented
+
+New app `kubernetes/apps/media/jellyfin/`:
+
+- `ks.yaml` — components `gpu` + `volsync` + `zeroscaler`; dependsOn `onepassword-connect`, `democratic-csi`, `intel-gpu-resource-driver`; `postBuild.substitute`: `APP: jellyfin`, `VOLSYNC_CAPACITY: "5Gi"`; `targetNamespace: media`
+- `app/helmrelease.yaml` — app-template 5.1.0 via the shared OCIRepository, `defaultPodOptions` style (NOT the reference's app-template v4 `controllers.x.pod` syntax); UID/GID/fsGroup 10001 (repo default, matches the VolSync mover); `readOnlyRootFilesystem: true`, drop ALL caps, seccomp RuntimeDefault; `/health` probes on 8096 with `startup: disabled` (sonarr pattern); `JELLYFIN_PublishedServerUrl` = the internal route URL; resources 25m CPU / 512Mi request, 4Gi memory limit
+- `app/pvc-metadata.yaml` — `jellyfin-metadata`, 10Gi, `democratic-csi-local-hostpath`
+- `app/kustomization.yaml` — pvc-metadata + helmrelease (no ExternalSecret: jellyfin needs no bootstrap secret; the VolSync ES comes from the component)
+- `kubernetes/apps/media/kustomization.yaml` — jellyfin ks.yaml registered
+
+Plex change (separate commit `8fbb42332`):
+
+- `plex/ks.yaml` — removed `components/gpu` and the `intel-gpu-resource-driver` dependsOn
+- `plex/app/helmrelease.yaml` — removed `defaultPodOptions.resourceClaims` and `resources.claims`
+
+Mounts that differ from the reference by intent:
+
+- `/cache` emptyDir instead of a separate `/transcode` volume — `JELLYFIN_CACHE_DIR=/cache` (from the image config) already holds the transcode working directory, so a second volume plus a UI path change would be redundant
+- `DOTNET_SYSTEM_IO_DISABLEFILELOCKING` omitted — the reference needs it for config on network storage; ours is a local-hostpath PVC
+
+## Verification (local, pre-deploy)
+
+- [verified] `yamllint` + `yamlfmt -lint` clean on all new/touched files
+- [verified] `pre-commit run --files …` — all applicable hooks Passed (gitleaks, yamlfmt, yamllint, secret check)
+- [verified] `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster` → **134 passed** (0 failed). Note: must run with `dangerouslyDisableSandbox` — inside the Bash sandbox every `helm template` OCI pull fails with the known Go TLS error `x509: OSStatus -26276`, which is environmental and unrelated to the change.
+- [verified] Rendered Deployment carries `resourceClaims: [{name: gpu, resourceClaimTemplateName: jellyfin-gpu}]`, `resources.claims: [{name: gpu}]`, all six volumeMounts (`/cache`, `/config`, `/metadata`, `/config/data/introskipper`, `/media`, `/tmp`), and the two CCNP labels
+- [verified] Rendered `ResourceClaimTemplate jellyfin-gpu` exists; `plex-gpu` is gone from the build output and the plex Deployment has no GPU claim
+- [verified] Rendered HTTPRoute: single `envoy-internal/https` parentRef, hostname `jellyfin.horvathzoltan.me`, Homepage annotations (group `Media`, icon `jellyfin.svg`)
+- [verified] Introskipper supports Jellyfin 12 — the upstream repo ships a dedicated `12.0/v1.12.0.1` release track next to `10.11`; manifest URL `https://intro-skipper.org/manifest.json` is version-aware and returns the right build per server version
+- [not verified] Nothing is deployed. Live behavior (pod scheduling with the freed GPU, VAAPI/QSV transcode, plugin install, NFS library scan) is post-merge work.
+
+## Post-deploy manual steps (Jellyfin UI, after Flux reconciles)
+
+1. Complete the Jellyfin setup wizard; add libraries from `/media`.
+2. Set the metadata path to `/metadata` (Dashboard → Playback/Library settings) so artwork lands on the non-backed-up PVC instead of the config PVC.
+3. Enable hardware acceleration → **Intel QuickSync (QSV)** or VAAPI on `/dev/dri/renderD128` (CDI-injected by the Intel DRA driver; same manual toggle plex needed).
+4. Add plugin repository `https://intro-skipper.org/manifest.json` → install **Intro Skipper** from the catalog → restart.
+5. Optional: add `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` → install **File Transformation** for the web-UI extras.
+6. Verify the Introskipper fingerprint DB materializes under `/config/data/introskipper` (i.e. on `jellyfin-metadata`, not the backed-up config PVC).
+
+## Follow-ups
+
+- [task] Plex now transcodes in software. Decide whether plex stays at all, or whether the shared-`ResourceClaim` route is worth revisiting so both servers can use the iGPU.
+- [task] If `seerr` should drive jellyfin (it currently targets plex), jellyfin will need a per-app CNP admitting `downloads/seerr` on 8096 — jellyfin has no CNP today.
+- [task] Update BM `docs/areas/k8s-workloads` after deployment: media namespace grows to 5 apps, and the "Plex GPU wiring" component claim becomes a jellyfin claim.
+- [task] Sizing is estimated from plex, not measured — revisit `requests.memory: 512Mi` / `limits.memory: 4Gi` and the 10Gi metadata PVC once the library is scanned.
+- [task] 12.0-rc5 is a pre-release. Watch for plugin ABI churn on rc bumps; Renovate PRs are review-gated, not auto-merged.

--- a/basic-memory/docs/progress/jellyfin.md
+++ b/basic-memory/docs/progress/jellyfin.md
@@ -33,7 +33,7 @@ permalink: home-ops/docs/progress/jellyfin
 New app `kubernetes/apps/media/jellyfin/`:
 
 - `ks.yaml` — components `gpu` + `volsync` + `zeroscaler`; dependsOn `onepassword-connect`, `democratic-csi`, `intel-gpu-resource-driver`; `postBuild.substitute`: `APP: jellyfin`, `VOLSYNC_CAPACITY: "5Gi"`; `targetNamespace: media`
-- `app/helmrelease.yaml` — app-template 5.1.0 via the shared OCIRepository, `defaultPodOptions` style (NOT the reference's app-template v4 `controllers.x.pod` syntax); UID/GID/fsGroup 10001 (repo default, matches the VolSync mover); `readOnlyRootFilesystem: true`, drop ALL caps, seccomp RuntimeDefault; `/health` probes on 8096 with `startup: disabled` (sonarr pattern); `JELLYFIN_PublishedServerUrl` = the internal route URL; resources 25m CPU / 512Mi request, 4Gi memory limit
+- `app/helmrelease.yaml` — app-template 5.1.0 via the shared OCIRepository, `defaultPodOptions` style (the reference pins the SAME chart version 5.1.0 but sets pod options per-controller via `controllers.jellyfin.pod`; this repo's house style is the global `defaultPodOptions`); UID/GID/fsGroup 10001 (repo default, matches the VolSync mover); `readOnlyRootFilesystem: true`, drop ALL caps, seccomp RuntimeDefault; `/health` probes on 8096 with `startup: disabled` (sonarr pattern); `JELLYFIN_PublishedServerUrl` = the internal route URL; resources 25m CPU / 512Mi request, 4Gi memory limit
 - `app/pvc-metadata.yaml` — `jellyfin-metadata`, 10Gi, `democratic-csi-local-hostpath`
 - `app/kustomization.yaml` — pvc-metadata + helmrelease (no ExternalSecret: jellyfin needs no bootstrap secret; the VolSync ES comes from the component)
 - `kubernetes/apps/media/kustomization.yaml` — jellyfin ks.yaml registered
@@ -46,7 +46,7 @@ Plex change (separate commit `8fbb42332`):
 Mounts that differ from the reference by intent:
 
 - `/cache` emptyDir instead of a separate `/transcode` volume — `JELLYFIN_CACHE_DIR=/cache` (from the image config) already holds the transcode working directory, so a second volume plus a UI path change would be redundant
-- `DOTNET_SYSTEM_IO_DISABLEFILELOCKING` omitted — the reference needs it for config on network storage; ours is a local-hostpath PVC
+- ~~`DOTNET_SYSTEM_IO_DISABLEFILELOCKING` omitted~~ — **CORRECTED 2026-08-21, now set to `"true"`.** The original rationale ("the reference needs it for config on network storage") was wrong: the reference's config PVC uses `storageClassName: ${KOPIUR_STORAGECLASS:=miroir-local}` (components/kopiur/backup/pvc.yaml), a local class just like ours. The flag's real target is the **NFS media mount**, which we have identically: .NET 6+ enforces `FileShare` with `flock()`, which is unreliable over NFS and surfaces as intermittent "file in use" IOExceptions during scan/playback. A `gh api search/code` over the reference repo returns exactly ONE hit for the variable (jellyfin only, not their .NET *arr apps), confirming it is a deliberate jellyfin-specific setting rather than a house-wide default.
 
 ## Verification (local, pre-deploy)
 
@@ -71,7 +71,30 @@ Mounts that differ from the reference by intent:
 ## Follow-ups
 
 - [task] Plex now transcodes in software. Decide whether plex stays at all, or whether the shared-`ResourceClaim` route is worth revisiting so both servers can use the iGPU.
-- [task] If `seerr` should drive jellyfin (it currently targets plex), jellyfin will need a per-app CNP admitting `downloads/seerr` on 8096 — jellyfin has no CNP today.
+- [task] Any in-cluster consumer of jellyfin needs a per-app CNP admitting it on 8096, because the baseline is ingress default-deny and jellyfin has no CNP today. Two concrete cases: (a) `seerr` if it should drive jellyfin instead of plex; (b) `sonarr`/`radarr`/`bazarr` library-refresh notifications (Connect → Emby/Jellyfin) — the reference's own CNP admits exactly `bazarr`, `sonarr`, `radarr`, `maintainerr` plus two apps we do not run (`mumc`, `jellyplex-watched`).
 - [task] Update BM `docs/areas/k8s-workloads` after deployment: media namespace grows to 5 apps, and the "Plex GPU wiring" component claim becomes a jellyfin claim.
 - [task] Sizing is estimated from plex, not measured — revisit `requests.memory: 512Mi` / `limits.memory: 4Gi` and the 10Gi metadata PVC once the library is scanned.
 - [task] 12.0-rc5 is a pre-release. Watch for plugin ABI churn on rc bumps; Renovate PRs are review-gated, not auto-merged.
+
+## Reference diff — full field-by-field audit (2026-08-21)
+
+Triggered by the human asking whether any other reference setting we skipped is actually needed.
+Reference: `bjw-s-labs/home-ops` @ main, `kubernetes/apps/media/jellyfin/` (helmrelease.yaml, ks.yaml,
+ciliumnetworkpolicy.yaml, ocirepository.yaml).
+
+**Adopted after the audit:**
+
+- [decision] `DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"` — ADDED. See the corrected rationale above (NFS media mount, not config storage).
+
+**Reviewed and deliberately NOT adopted, with evidence:**
+
+- [decision] `service.app.ports.http.appProtocol: kubernetes.io/ws` — **verified no-op for us.** Envoy Gateway's `kubernetes.io/ws` / `kubernetes.io/wss` handling does NOT enable websocket support (Envoy upgrades websockets on HTTP routes regardless); per the EG v1.8.1 release note it "force[s] HTTP/1.1 upstream connections instead of negotiating HTTP/2, avoiding compatibility issues with WebSocket backends that do not support RFC 8441 extended CONNECT", implemented in `internal/gatewayapi/route.go` (`shouldForceHTTP1Upstream`). Our EG is 1.9.0 and we set no `kubernetes.io/h2c`, BackendTrafficPolicy, or BackendTLSPolicy that would push the upstream to HTTP/2, so the upstream is already HTTP/1.1. Zero `appProtocol` occurrences exist anywhere in this repo. Becomes relevant only if HTTP/2-to-backend is ever enabled.
+- [decision] Per-app `ciliumnetworkpolicy.yaml` — not needed for the envoy-internal ingress, which the `ingress-from-gateway-internal` CCNP already grants (the reference has no such CCNP layer, so they must spell the gateway out in the app CNP). Their CNP additionally admits `bazarr`, `sonarr`, `radarr`, `maintainerr`, `mumc`, `jellyplex-watched` — see the consumer follow-up above; none of those integrations are wired here yet.
+- [decision] Probes — reference: `initialDelaySeconds: 0`, `periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 3`. Ours: 30/30/5/5 (sonarr house pattern). Ours is deliberately more forgiving, which matters for a 12.0-rc first boot that may run DB migrations. Kept.
+- [decision] Resources — reference: `requests.cpu: 100m`, NO memory request, `limits.memory: 8Gi`. Ours: 25m + 512Mi request, 4Gi limit. A memory request is mandatory per the repo resource baseline; 8Gi is not defensible on a single node that also runs plex. Kept, revisit after measurement.
+- [decision] Metadata PVC — reference declares it chart-managed (`persistence.metadata.size/accessMode/storageClass/suffix`). Ours is an explicit `pvc-metadata.yaml` matching `plex-rebuildable`. Same resulting name (`jellyfin-metadata`); ours survives a HelmRelease deletion, which is the safer lifecycle.
+- [decision] NFS mount shape — reference mounts a `Library` subPath at `/data/nas-media/Library`. We mount `${NAS_IP}:/media` wholesale at `/media`, matching plex/sonarr/radarr so library paths line up with the *arr import paths. Kept.
+- [decision] `tmpfs` single emptyDir with cache/tmp/transcode subPaths — split into `cache` + `tmp` emptyDirs here; the transcode dir lives under `JELLYFIN_CACHE_DIR=/cache` anyway.
+- [decision] Per-app `ocirepository.yaml` — the reference pins app-template 5.1.0 per app; this repo consumes the shared `components/common/repos/app-template` OCIRepository at the same 5.1.0. No per-app file needed.
+- [decision] Pod `securityContext` — reference runs UID/GID 2000 with no `runAsNonRoot` and no `seccompProfile`. Ours is strictly harder (10001 + `runAsNonRoot: true` + RuntimeDefault + drop ALL + `readOnlyRootFilesystem`). Kept.
+- [decision] `service.type: LoadBalancer` + `externalTrafficPolicy: Local` — dropped per the exposure decision (envoy-internal only).

--- a/basic-memory/docs/progress/media-library-integrity-audit.md
+++ b/basic-memory/docs/progress/media-library-integrity-audit.md
@@ -10,7 +10,7 @@ permalink: home-ops/docs/progress/media-library-integrity-audit
 
 - [type] progress-note
 - [topic] Repeatable cross-check methodology for Sonarr/Radarr DB vs. disk vs. Plex: stale DB rows, untracked files on disk, and on-disk duplicates
-- [status] runbook — Phase 0-6 defined; a full pass has NOT been run end-to-end yet. The baseline numbers below were measured 2026-08-21.
+- [status] runbook — Phase 0-6 defined; first full end-to-end pass run 2026-08-21 (read-only, see "Pass 1" below). Baseline numbers in the table further down are the 2026-08-21 pre-pass figures and are already superseded in part.
 - [area] k8s-workloads
 - [created] 2026-08-21
 - [relates_to] [[k8s-workloads]]
@@ -343,3 +343,25 @@ target directories" and "expected 47 files", aborting on any mismatch.
 
 - part_of [[k8s-workloads]]
 - relates_to [[jellyfin]]
+
+## Pass 1 — full end-to-end run, 2026-08-21 09:2x (read-only)
+
+First complete Phase 0-6 pass. Nothing was mutated: no deletes, no rescans, no API writes.
+Method exactly as specified above (all disk checks in-pod over NFS, keys derived in-pod, per-file
+`stat`, `comm` diffs, summing in local python). Jellyfin is **not deployed yet** on this cluster, so
+the Jellyfin third-source cross-check (open finding 7) could not run.
+
+
+### Two methodology corrections for the next pass
+
+1. **Detect a missing series folder from a directory listing, not from the file manifest.** Deriving
+   presence from file paths silently reports every file-less tombstone as "folder missing" (81
+   instead of 2 here). Take `find <roots> -type d` and test the record's `path` against that set.
+2. **busybox `find` in the Sonarr pod has no `-newermt`** (in addition to the documented missing
+   `-printf`). Use `-mmin -N`, or read directory mtimes with `stat -c %y`. `find ... -exec stat -c
+   '%s|%n' {} +` is the fast way to build the manifest and it works.
+
+
+A jq note for the next pass: `.id + " " + .status` on a Sonarr `/command` response throws
+(`number and string cannot be added`) because `.id` is numeric — the POST still succeeded and the
+command ran. Use string interpolation instead of `+`.

--- a/basic-memory/docs/progress/media-library-integrity-audit.md
+++ b/basic-memory/docs/progress/media-library-integrity-audit.md
@@ -1,0 +1,345 @@
+---
+title: media-library-integrity-audit
+type: note
+permalink: home-ops/docs/progress/media-library-integrity-audit
+---
+
+# media-library-integrity-audit — cross-check runbook (Sonarr / Radarr / disk / Plex)
+
+## Metadata (observation-form)
+
+- [type] progress-note
+- [topic] Repeatable cross-check methodology for Sonarr/Radarr DB vs. disk vs. Plex: stale DB rows, untracked files on disk, and on-disk duplicates
+- [status] runbook — Phase 0-6 defined; a full pass has NOT been run end-to-end yet. The baseline numbers below were measured 2026-08-21.
+- [area] k8s-workloads
+- [created] 2026-08-21
+- [relates_to] [[k8s-workloads]]
+- [relates_to] [[jellyfin]]
+
+## Why this note exists
+
+The 2026-08-20/21 session canonicalised 223 Sonarr series folders and, while verifying, kept finding
+integrity problems that **no single app surfaces on its own**. The apps' own health and unmapped-folder
+checks are folder-level and reported clean the whole time. Every real defect was found by *diffing two
+sources against each other*.
+
+This note is the runbook for repeating that diff deliberately, from a cold session.
+
+## Hard preconditions — the reflex list (all learned the hard way)
+
+1. **Every disk check runs INSIDE the pod (NFS).** The macOS `/Volumes/media` SMB mount serves a stale
+   directory cache and will lie to you.
+2. **Cluster commands need `dangerouslyDisableSandbox: true`** (kubectl/flux/talosctl and the
+   `just k8s` / `just volsync` recipes). Symptom otherwise: `operation not permitted`.
+3. **The API key never leaves the pod.** Derive it in-pod every time from `/config/config.xml`.
+   Do NOT grep a config file in a way that prints a key into the transcript — that happened once
+   this session with the Bazarr key and forced a rotation.
+4. **When piping a script via `kubectl exec -i ... sh -s`, EVERY curl needs a redirect from
+   `/dev/null`** or curl eats the rest of the script from stdin. Exception: when POSTing a body from
+   stdin, drop it.
+5. **busybox in the pod**: no `python3`; `find` has no `-printf` (loop over the results and call
+   `stat -c %s` per file); **busybox awk overflows at 2^31** on large byte sums (returns
+   `-2147483648`) so do all summing in local python3.
+6. **Local scratch**: `/tmp` is NOT writable in the sandbox. Use `$TMPDIR` or the session scratchpad.
+   (`/tmp` *inside the pod* is fine.)
+7. **The bang-guard hook blocks `!=` / `!r` in an inline python `-c` or heredoc.** Write the script to
+   a file under `$TMPDIR` and run the file.
+8. **The code-executor blocks note content containing shell-command text.** Write the markdown to a
+   scratchpad file with the Write tool, then have the sandbox read that file and pass it to
+   `write_note` — the sandbox code itself then contains no flagged tokens.
+9. **Recycle Bin is NOT configured in either Sonarr or Radarr** and `/media` has **no file-level
+   backup** (resticprofile only covers `/backups`,
+   `kubernetes/apps/selfhosted/resticprofile/app/config/profiles.yaml:26-27`). Every delete is final.
+   Always print an itemised list with byte sizes first, and put count/size assertions in the script.
+10. **Plex `autoEmptyTrash` defaults to 1** — a scan deletes immediately. Set it to 0 for the duration
+    of any move/rename/delete, empty the trash explicitly afterwards, then restore it to 1.
+11. **Plex JSON can contain raw control characters** that break `jq` (hit on sections 2 and 8 while
+    building the baseline below). Fall back to the XML response, or strip control chars first.
+12. **The allLeaves endpoint does NOT return `Stream` data.** For subtitle/stream checks use the full
+    per-item metadata endpoint with `checkFiles=1`. An empty subtitle list from allLeaves is a
+    measurement artefact, not a finding.
+
+## Two API facts that make or break the whole audit
+
+- **Sonarr stores RELATIVE paths.** `episodefile.relativePath` is the stored value; `episodefile.path`
+  is *computed* against the current `series.Path`. So a file physically sitting in the wrong directory
+  can still show a perfectly canonical `path` in the API. **This is why the DB-to-disk existence test
+  (Phase 1) is the only reliable detector** — comparing strings will never find it.
+- **`statistics.episodeFileCount` is NOT the number of `episodefile` rows.** A persistent -3 offset was
+  observed on Puppy Dog Pals (71 rows vs 68 in statistics), and it survived a file deletion. **Never
+  use `statistics` for integrity work** — enumerate the episodefile endpoint instead. Root cause of the
+  offset is still undiagnosed and is a candidate finding for the next pass.
+
+## Endpoint map
+
+| | Sonarr | Radarr |
+|---|---|---|
+| deploy | `-n downloads deploy/sonarr -c app` | `-n downloads deploy/radarr -c app` |
+| port | 8989 | 7878 |
+| items | `/api/v3/series` | `/api/v3/movie` |
+| files | `/api/v3/episodefile?seriesId=X` | `.movieFile.path` inline on `/api/v3/movie` |
+| roots | `/api/v3/rootfolder` (carries `unmappedFolders`) | same |
+| naming | `/api/v3/config/naming` | same |
+| rename preview | `/api/v3/rename?seriesId=X` | `/api/v3/rename?movieId=X` |
+| wanted | `/api/v3/wanted/missing`, `/api/v3/wanted/cutoff` | same |
+| delete a file | `DELETE /api/v3/episodefile/bulk` with `episodeFileIds` | `DELETE /api/v3/moviefile/bulk` |
+
+Plex: `-n media deploy/plex -c app`, port 32400, token from `PlexOnlineToken` in
+`/config/Library/Application Support/Plex Media Server/Preferences.xml`.
+
+Root folders: Sonarr owns `/media/shows`, `/media/kids_shows`, `/media/docuseries`.
+Radarr owns `/media/movies`, `/media/kids_movies`, `/media/docufilms`.
+
+## Phase 0 — snapshot before touching anything
+
+Dump to the session scratchpad so every later phase diffs against a fixed point:
+
+- full `/api/v3/series` and `/api/v3/movie` JSON
+- the tracked-path list (Phase 1)
+- a file-level disk manifest of `size|path` for **every** file (not just video) under all six roots
+- Plex per-leaf state for every show section: ratingKey, parentIndex, index, viewCount, lastViewedAt, file
+
+The file-level manifest is the strongest guard available: after any operation the multiset of
+`(size, path-relative-to-series-dir)` must be **identical**, or differ by exactly the itemised intended
+change. This is what proved 3150 files / 9 008 828 485 097 bytes untouched across 223 folder renames.
+
+## Phase 1 — DB to disk (the app claims a file that is not there)
+
+Build the tracked-path list, then test each path for existence:
+
+```
+K from /config/config.xml
+GET /api/v3/series -> jq -r '.[].id'
+for each id: GET /api/v3/episodefile?seriesId=$id -> jq -r '.[].path'
+sort -> tracked.txt
+for each path: test -f, count the failures
+```
+
+Radarr needs no loop: `GET /api/v3/movie` then `jq -r '.[]|select(.hasFile)|.movieFile.path'`.
+
+**Expected: 0.** Non-zero means one of:
+
+- a file was deleted outside the app (a manual SMB delete leaves no history entry)
+- an import landed at a stale path (see the Outer Banks finding below)
+- an NFS or disk problem
+
+**Fix**: locate the file, move it into place if it exists elsewhere, then `RescanSeries`. If it is
+genuinely gone, `RescanSeries` clears the rows — but check `monitored` FIRST (see the re-download trap).
+
+## Phase 2 — disk to DB (files nothing tracks)
+
+**`rootfolder.unmappedFolders` is NOT sufficient.** It only sees whole folders that no record claims.
+It reported empty on every root while 15 untracked video files existed *inside* mapped series and movie
+folders. Do the file-level diff instead, and use `comm` on two sorted lists (O(n log n)) rather than a
+`grep -Fxq` loop (O(n^2) — it works but is slow on ~3000 files):
+
+```
+find <the three roots> -type f \( -name '*.mkv' -o -name '*.mp4' -o -name '*.avi' \
+  -o -name '*.m4v' -o -name '*.ts' -o -name '*.wmv' \) | sort > disk.txt
+comm -23 tracked.txt disk.txt   # tracked but absent  = Phase 1 restated
+comm -13 tracked.txt disk.txt   # present but untracked
+```
+
+Classify every untracked file before acting:
+
+- **unparseable numbering** — the app cannot map it (Paw Patrol `S04E01a` / `S04E01b` half-episode splits)
+- **superseded duplicate** — a better version is tracked in the same folder (The Irishman 720p)
+- **sample or trailer** — see Phase 4
+- **genuinely importable** — manual import. Never hand-build the quality/languages objects; take them
+  from Sonarr's own `/api/v3/manualimport` analysis, and do **not** pass `seriesId` to that endpoint or
+  it scans a not-yet-existing folder and throws `DirectoryNotFoundException`.
+
+## Phase 3 — on-disk duplicates
+
+**3a — the same episode twice inside one series.** Extract the `SxxEyy` token from every video filename
+per series folder, group, report groups larger than one. Watch for legitimate multi-episode files
+(`S01E01E02`) and for the `a`/`b` split suffix.
+
+**3b — the same season present in two directory trees.** This is the highest-value check; it found
+6.68 GiB. Within a series folder, map each immediate subdirectory to the set of season numbers it
+contains (parsed from filenames); a season number appearing under **more than one** subdirectory is a
+duplicate season. Jellyfin's own season regex is a good detector for release-style directory names:
+`[sS](\d{1,4})(?!\d|[eE]\d)(?=\.|_|-|\[|\]|\s|$)` — it resolves `Paw.Patrol.S08` and
+`The.Wire.S01.1080p...`.
+
+**3c — movie folders holding more than one video.** Iterate each movie root, count video files per
+folder, report any count above one.
+
+**3d — duplicate records** (not files): duplicate `imdbId`, duplicate `(title, year)`, duplicate `path`
+across all records. This doubles as the **collision guard** before any bulk rename: because the folder
+format is a pure function of `(title, year, imdbId)`, a unique `imdbId` across the set *proves* that no
+two records can produce the same folder name — there is no need to compute the names at all.
+
+**Do not hash 8 TB.** Group by byte size first; only investigate size collisions.
+
+## Phase 4 — DB garbage classes
+
+Enumerate, then judge. Several of these are **intentional** here (see the next section).
+
+| Class | How to find it | Verdict |
+|---|---|---|
+| record with 0 files AND no folder on disk | `episodeFileCount == 0` plus a directory test | tombstone — keep |
+| `imdbId` is null | `select(.imdbId == null)` | folder format yields a bare `{imdb-}` |
+| path outside every root folder | compare the `path` prefix to each `rootfolder[].path` | real defect |
+| sample or trailer imported as media | tracked `relativePath` matching sample/trailer, case-insensitive | real defect |
+| improbably small tracked file | size below 25% of that series' **median** file size | see the pitfall below |
+| `monitored` true + 0 files + monitored episodes | see the re-download trap | real risk |
+| `episodefile` rows not linked to any episode | join `episodefile.id` against `episode.episodeFileId` | explains the -3 offset? |
+
+**Pitfall — never use an absolute size threshold.** A "below 100 MB" filter flagged roughly 50
+legitimate Fireman Sam episodes (95-99 MB each; short kids episodes). Compare against the per-series
+median instead.
+
+**Pitfall — never infer episode monitoring from the season flag.** `High Score (2019)` had
+`series.monitored` true and season 1 monitored true while **all 8 episodes were monitored false**.
+Measure at the episode level, or read `/api/v3/wanted/missing` — that is the authoritative answer to
+"would the monthly search try to download this?".
+
+**The re-download trap.** A stale DB can *hide* the risk. While Sonarr still believed
+`Waterspider-Wonderspider` had 39 files it contributed 0 to `wanted`. A `RescanSeries` would have
+turned it into 39 monitored-and-missing episodes, and
+`kubernetes/apps/downloads/arr-search/app/config/scripts/arr-search.sh:57` fires
+`MissingEpisodeSearch` on the **first Saturday of every month**. **Always set `monitored` to false
+FIRST, then rescan.** Never the other way round.
+
+## Phase 5 — cross-app consistency
+
+- **Plex against Sonarr, per series**: Plex `leafCount` versus the tracked file count. A gap means Plex
+  indexed files the app does not track, or the reverse.
+- **Bazarr against Sonarr**: `GET /api/series` on port 6767 with an `X-API-KEY` header, key from
+  `/config/config/config.yaml`. Every path should be canonical. Bazarr re-syncs paths from Sonarr
+  automatically; the only 2 non-canonical entries were exactly the 2 records with no `imdbId`.
+- **Orphan subtitles**: any `.srt` whose stem has no matching video file.
+- **qbittorrent**: confirm no save path points into a media root. `Session\DefaultSavePath` is
+  `/media/downloads/complete` and `Session\TempPath` is `/media/downloads/incomplete`. With
+  `copyUsingHardlinks` true the torrent lives under `/media/downloads` and hardlinks are inode-based,
+  so media-side renames **cannot** break seeding. Verified 2026-08-21.
+
+## Phase 6 — structural cruft
+
+- non-`Season` subdirectories inside series folders — classify by whether they still hold a **tracked**
+  file. Only the ones that do not are safe to delete.
+- directories holding nothing but `.nfo` or `.DS_Store`
+- empty directories
+- `.DS_Store` — **do not chase**; macOS Finder recreates it on every SMB browse.
+
+The deletion guard pattern that worked: re-derive the target list inside the pod (never trust a list
+carried over from earlier analysis), then assert exact counts before deleting, for example "expected 15
+target directories" and "expected 47 files", aborting on any mismatch.
+
+## What NOT to "fix"
+
+- **File-less orphan records are intentional tombstones.** 77 in Sonarr, 57 in Radarr. They prevent
+  accidental re-adding. Count and list them; **never bulk-delete**.
+- **Release-style subdirectories that still contain tracked files** are legitimate — the episode-file
+  rename (tranche T4) has deliberately not been run. 27 such directories in the Sonarr roots.
+- **The 2 records with no `imdbId`** (`High Score (2019)` tvdb=395404, `Restricted Zones` tvdb=412255).
+  The folder token renders as a literal `{imdb-}` when the id is empty — measured, and **not fixable in
+  the naming format**, because the braces are literal text and Sonarr has no conditional-token syntax.
+  Both are monitored false and have no folder on disk.
+- **A large `wanted/cutoff` count is by design** (~1087). The quality profile is `WEB-2160p (Combined)`
+  while most of the library is 1080p.
+- **`Indexers unavailable: Ncore (Prowlarr)`** and its "Download selectors didn't match" HTTP 500s are
+  a pre-existing indexer issue, unrelated to library integrity.
+
+## Baseline measured 2026-08-21 (after the folder-canonicalisation session)
+
+| | value |
+|---|---|
+| Sonarr series records | 244 |
+| Sonarr tracked episode files | 2777 |
+| video files on disk in Sonarr's 3 roots | 2791 |
+| **Sonarr DB-to-disk missing** | **0** |
+| **Sonarr disk-to-DB untracked** | **14** (all Paw Patrol S04 `Exxa`/`Exxb` splits) |
+| directories: shows / kids_shows / docuseries | 143 / 7 / 17 |
+| Radarr movie records | 271 (57 with no file) |
+| Radarr tracked movie files | 214 |
+| video files on disk in Radarr's 3 roots | 215 |
+| **Radarr DB-to-disk missing** | **0** |
+| **Radarr disk-to-DB untracked** | **1** (The Irishman 720p) |
+| movie folders with more than one video | **1** (The Irishman) |
+| `unmappedFolders` on all 6 roots | 0 |
+| non-`Season` subdirs holding tracked files | 27 |
+| `.nfo` / `.DS_Store` in the Sonarr roots | 47 / 12 |
+| Plex Series (key 2) | 141 items / 2029 leaves / 218 viewed |
+| Plex Kids shows (key 4) | 7 / 654 / 653 |
+| Plex Docuseries (key 5) | 17 / 102 / 33 |
+| Plex Movies (1) / Kids movies (3) / Docufilms (8) | 28 / 164 / 22 items |
+
+## Open findings carried into the next pass
+
+1. **Paw Patrol S04 — 14 untracked files.** `S04E01a` / `S04E01b` style half-episode splits that Sonarr
+   cannot map. Decide: manual import as multi-episode files, rename to a mappable form, or delete as
+   redundant. Check first whether S04 is *also* covered by tracked files, i.e. whether this is a
+   duplicate season.
+2. **The Irishman — 1 untracked 720p duplicate.** `the.irishman.720p-no1.mkv`, 5 960 528 723 bytes
+   (5.55 GiB), sitting beside the tracked `WEBRip-2160p` file of 20 356 322 632 bytes. Almost certainly
+   safe to delete; itemise and confirm first.
+3. **The `episodeFileCount` -3 offset** on Puppy Dog Pals (71 rows versus 68). Diagnose by joining
+   `episodefile.id` against `episode.episodeFileId`.
+4. **Radarr's 3 file-less documentary records** (A Reindeer's Journey, Parrot Confidential, Chasing Ice)
+   plus roughly 57 file-less records overall — tombstones, do not clean.
+5. **Bazarr API key rotation** is outstanding (leaked into a transcript on 2026-08-20).
+6. **Tranche T4 episode renames** remain undone: 8 series, 642 files, 647 watched marks. Measured to be
+   safe (720/720 Plex-to-Sonarr episode-mapping agreement) but low value.
+7. **Re-run Phase 1 and Phase 2 right after Jellyfin's first library scan.** Jellyfin 10.11.11 is being
+   introduced on branch `feat/jellyfin` and will mount the same `${NAS_IP}:/media` wholesale at
+   `/media`. It only reads, so it cannot create the defects this runbook hunts — but its own item
+   counts are a third independent source to diff against Sonarr's 2777 tracked files and Plex's 2029 +
+   654 + 102 leaves. A gap on any side is a finding. Do the first scan read-only and compare before
+   trusting it.
+
+## Findings from the 2026-08-20/21 session that motivated this runbook
+
+- **Stray import after a folder rename.** 8 Outer Banks S05 files (38.7 GiB) were imported by Sonarr
+  into the **pre-rename** path 2.5 hours after the rename, while the DB showed a perfectly canonical
+  `path` — because Sonarr stores relative paths. Only the Phase 1 existence test found it. Likely
+  cause: a `TrackedDownload` grabbed before the rename carries a snapshot of the old `series.Path`.
+  `SeriesRepository` is a plain `BasicRepository<Series>` with no cache layer, so it is not a caching
+  bug. **Always re-run Phase 1 after any bulk folder rename, and prefer doing such renames when the
+  download queue is quiet.**
+- **Samples masquerading as episodes.** Puppy Dog Pals `S01E01`, `S02E01` and `S04E01` were represented
+  *only* by roughly 35 MB release sample clips inside `Sample/` subdirectories. Sonarr reported
+  `hasFile` true and 100%; Plex ignored them because of the `Sample/` convention. An episode rename
+  would have promoted them into `Season xx/` under canonical names, making Plex index three fake
+  episodes. Deleted through the episodefile bulk-delete endpoint; the three episodes are now honestly
+  missing and monitored false.
+- **A duplicate season worth 6.68 GiB.** `Vienna Blood` held a 720p two-part Hungarian S01 release
+  (3 untracked `.mkv` plus 6 `.hu.srt`) alongside the tracked 1080p S01 in `Season 01`.
+- **A series split across two folders.** `The Wire` had a 13-file S01-only Bluray-Remux folder
+  (Sonarr-tracked) and a 60-file complete S01-S05 Hungarian folder (unmapped). Resolved by deleting the
+  partial one, renaming the complete one to the canonical name, and running `RescanSeries` — 60/60.
+- **A 2023 mis-mapping still live.** `High Score (2019)` (an SB Nation sports docuseries, 0 episodes on
+  TVDB, no imdb or tmdb id) owned a folder named `High.Seas.2019`; its history shows
+  `episodeFileDeleted` events for *High Seas* files. A separate, correct `High Seas` record exists. Set
+  to monitored false.
+- **Manual SMB deletions leave no app-side trace.** Two kids series (78 files, 50.7 GiB) were deleted by
+  the human directly on the filesystem. Sonarr history had nothing and Maintainerr logged
+  "No data was altered". Only Phase 1 caught it (missing = 78).
+- **Subtitles do follow a rename.** `RenameEpisodeFileService.RenameFiles()` publishes
+  `SeriesRenamedEvent`, which `ExtraService` handles by calling `MoveFilesAfterRename`. Measured: all
+  Bazarr-created `.hu.srt` files were renamed with their video and Plex re-attached them as external
+  subtitle streams. An episode rename therefore does **not** orphan the 277 subtitle files.
+- **Jellyfin reads the `{imdb-...}` folder tag — but on the version we ship, only via a fallback.**
+  The deployed target is **stable `10.11.11`** (see [[jellyfin]]; the 12.0-rc5 pin was revised on
+  2026-08-21). In `PathExtensions.GetAttributeValue`, **10.11.x accepts only `[` as the opening
+  character and searches for the literal `imdbid`**, so our `{imdb-tt...}` form fails the attribute
+  path on two counts. It still resolves, because the `imdbid` branch ends in an unconditional
+  `ProviderIdParsers.TryFindImdbId` fallback that finds `tt` plus 7-8 digits anywhere in the string.
+  Verified this is unambiguous here: every series folder contains **exactly one** `tt` id, no folder
+  contains more than one, and none contains the literal `imdbid` — so the fallback cannot mis-fire.
+  A `{tmdb-...}` or `{tvdb-...}` tag would **NOT** work on 10.11 at all; no pattern fallback exists for
+  those, which is precisely the mis-match jellyfin issue 14928 reports. Both Sonarr and Radarr here
+  write IMDb only, so we are safe. For reference, 12.x accepts `{`, `(` and `[` and aliases `imdbid` to
+  `imdb` (jellyfin PR 14927, merged 2026-02-02, confirmed an ancestor of the `v12.0-rc5` tag) — so a
+  future 12.x bump upgrades this from the fallback to the proper attribute parser, and needs no
+  filesystem change. **Do not "fix" the folders to `[imdbid-...]`** — it buys nothing on either track.
+- **Episode filenames are already Jellyfin-parseable.** 2791 of 2791 video files carry an `SxxExx`
+  pattern, and every directory chain carries a season signal (2140 via a `Season` keyword directory,
+  651 via a release directory matching Jellyfin's own season-prefix regex, 0 with no signal). The
+  pending episode renames are therefore **not** required for Jellyfin.
+
+## Relations
+
+- part_of [[k8s-workloads]]
+- relates_to [[jellyfin]]

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jellyfin
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      # AD-023 vocabulary: envoy-internal only (ingress-from-gateway-internal CCNP) + internet egress via the allow-world-egress CCNP,
+      # needed for metadata providers and the plugin catalog / Introskipper downloads (same class as plex and the *arr apps).
+      labels:
+        ingress.home.arpa/allow-gateway-internal: "true"
+        egress.home.arpa/allow-world: "true"
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: "${APP}-gpu"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      jellyfin:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/jellyfin/jellyfin
+              tag: 12.0-rc5@sha256:669d234c776a37b331d875f58246434f80dbbbb619fa7edef55ce26d187baa2c
+            env:
+              JELLYFIN_PublishedServerUrl: "https://jellyfin.${PUBLIC_DOMAIN}"
+            securityContext:
+              privileged: false
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8096
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: false
+            resources:
+              claims:
+                - name: gpu
+              requests:
+                cpu: 25m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+    service:
+      app:
+        controller: jellyfin
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Jellyfin
+          gethomepage.dev/group: Media
+          gethomepage.dev/icon: jellyfin.svg
+        hostnames:
+          - "jellyfin.${PUBLIC_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: networking
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        existingClaim: jellyfin
+        globalMounts:
+          - path: /config
+      # Rebuildable, deliberately NOT backed up: library artwork/metadata (point the
+      # Jellyfin metadata path at /metadata in the UI) and the Introskipper fingerprint DB.
+      metadata:
+        existingClaim: jellyfin-metadata
+        advancedMounts:
+          jellyfin:
+            app:
+              - path: /metadata
+                subPath: metadata
+              - path: /config/data/introskipper
+                subPath: introskipper
+      nfs-nas-media:
+        type: nfs
+        server: ${NAS_IP}
+        path: /media
+        globalMounts:
+          - path: /media
+      # JELLYFIN_CACHE_DIR=/cache also holds the transcode working directory.
+      cache:
+        type: emptyDir
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -39,6 +39,8 @@ spec:
               repository: ghcr.io/jellyfin/jellyfin
               tag: 12.0-rc5@sha256:669d234c776a37b331d875f58246434f80dbbbb619fa7edef55ce26d187baa2c
             env:
+              # .NET enforces FileShare with flock(), which is unreliable on the NFS media mount.
+              DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"
               JELLYFIN_PublishedServerUrl: "https://jellyfin.${PUBLIC_DOMAIN}"
             securityContext:
               privileged: false

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jellyfin/jellyfin
-              tag: 12.0-rc5@sha256:669d234c776a37b331d875f58246434f80dbbbb619fa7edef55ce26d187baa2c
+              tag: 10.11.11@sha256:45f648c382a0c8b552582fcea40e95cb17c5d475473a891cba0eb7523fb92112
             env:
               # .NET enforces FileShare with flock(), which is unreliable on the NFS media mount.
               DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc-metadata.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/jellyfin/app/pvc-metadata.yaml
+++ b/kubernetes/apps/media/jellyfin/app/pvc-metadata.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-metadata
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: democratic-csi-local-hostpath

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: jellyfin
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: jellyfin
+  components:
+    - ../../../../components/gpu
+    - ../../../../components/volsync
+    - ../../../../components/zeroscaler
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: democratic-csi
+      namespace: kube-system
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+  interval: 1h
+  path: ./kubernetes/apps/media/jellyfin/app
+  postBuild:
+    substitute:
+      APP: jellyfin
+      VOLSYNC_CAPACITY: "5Gi"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   # Flux-Kustomizations
   - ./plex/ks.yaml
   - ./plex-trakt-sync/ks.yaml
+  - ./jellyfin/ks.yaml
   - ./calibre-web-automated/ks.yaml
   - ./isponsorblocktv/ks.yaml

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -17,9 +17,6 @@ spec:
       labels:
         ingress.home.arpa/none: "true"
         egress.home.arpa/allow-world: "true"
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: "${APP}-gpu"
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
@@ -72,8 +69,6 @@ spec:
                   tcpSocket:
                     port: *port
             resources:
-              claims:
-                - name: gpu
               requests:
                 cpu: 25m
                 memory: 160Mi

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -9,15 +9,12 @@ spec:
     labels:
       app.kubernetes.io/name: plex
   components:
-    - ../../../../components/gpu
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
     - name: democratic-csi
-      namespace: kube-system
-    - name: intel-gpu-resource-driver
       namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/media/plex/app


### PR DESCRIPTION
## What

Adds Jellyfin as a second media server in the `media` namespace, modelled on the [bjw-s-labs reference](https://github.com/bjw-s-labs/home-ops/blob/main/kubernetes/apps/media/jellyfin/app/helmrelease.yaml) and adapted to this repo's conventions, with Introskipper support prepared.

Image: `ghcr.io/jellyfin/jellyfin:10.11.11@sha256:45f648c382a0c8b552582fcea40e95cb17c5d475473a891cba0eb7523fb92112` — the stable release, byte-identical to the tag+digest the reference pins. (An earlier round of this branch pinned `12.0-rc5`; switched to stable on request. Note the registry has no `v10.11.11` tag — no `v` prefix.) Introskipper accordingly runs on its stable `10.11` track, whose stated requirement is Jellyfin 10.11.11+.

## Decisions worth reviewing

| Topic | Choice | Why |
|---|---|---|
| **GPU** | iGPU claim moved **from plex to jellyfin** | The node advertises exactly one `gpu.intel.com` device (`allowMultipleAllocations: None`) and plex's DRA claim held it — a second claim would leave the jellyfin pod `Pending` forever. Plex falls back to software transcode. |
| **Exposure** | `envoy-internal` HTTPRoute only, **no LoadBalancer** | Differs from the reference (which also adds an LB IP) and from plex (LB-only, no route). No new cluster-setting IP. |
| **OIDC** | `components/gateway-oidc` deliberately **not** attached | The Envoy OIDC redirect breaks native Jellyfin clients; internal-only route + Jellyfin's own auth is the boundary. |
| **Egress** | `egress.home.arpa/allow-world: "true"`, **no per-app CNP** | A media server needs metadata-provider CDNs (TMDB/TVDB) on top of the plugin catalog. Every sibling in the same class (plex, sonarr, radarr) uses `allow-world`; an FQDN allowlist would be fragile. |
| **Storage** | config PVC (5Gi, VolSync) + separate `jellyfin-metadata` PVC (10Gi, **not** backed up) | Mirrors the `plex` / `plex-rebuildable` split. The metadata PVC also carries `/config/data/introskipper` so the fingerprint DB never enters a backup. |

Deviations from the reference by intent: `/cache` emptyDir instead of a separate `/transcode` volume (`JELLYFIN_CACHE_DIR=/cache` already holds transcode temp), and `/media` mounted wholesale instead of a `Library` subPath so paths line up with the *arr apps.

### Reference audit (added after review)

`DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"` was initially omitted on a wrong rationale and has now been **added** (commit `dba68a9b7`): the reference's config PVC is a local storage class too, so the flag's real target is the NFS **media** mount — .NET 6+ enforces `FileShare` with `flock()`, unreliable over NFS.

Every other remaining deviation was reviewed field by field and deliberately kept:

- `appProtocol: kubernetes.io/ws` — **verified no-op here.** In Envoy Gateway this does not enable websockets (Envoy upgrades them anyway); per the EG v1.8.1 release note it only forces HTTP/1.1 upstream instead of negotiating HTTP/2 (`shouldForceHTTP1Upstream` in `internal/gatewayapi/route.go`). We run EG 1.9.0 with no `h2c`/BackendTrafficPolicy/BackendTLSPolicy pushing the upstream to HTTP/2, so it is already HTTP/1.1.
- per-app CNP — our `ingress-from-gateway-internal` CCNP already grants the gateway ingress the reference has to spell out. Their extra consumers (`bazarr`, `sonarr`, `radarr`, `maintainerr`) become relevant only when those integrations are wired; then jellyfin needs its own CNP on 8096.
- probes 30/30/5/5 (house pattern) instead of 0/10/1/3 — more forgiving, which matters for a first boot that may run DB migrations.
- resources 25m + 512Mi request / 4Gi limit instead of 100m + no memory request / 8Gi — memory requests are mandatory per the repo baseline, and 8Gi is not defensible on a single node also running plex.
- explicit `pvc-metadata.yaml` instead of a chart-managed PVC — matches `plex-rebuildable` and survives a HelmRelease deletion.
- stricter `securityContext` (10001, `runAsNonRoot`, RuntimeDefault, drop ALL, read-only rootfs) vs the reference's UID 2000 without them.

Both repos pin the **same** app-template 5.1.0; the reference sets pod options per-controller (`controllers.jellyfin.pod`), this repo's house style is the global `defaultPodOptions`.

## Verification (local, pre-deploy)

- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster` → **134 passed, 0 failed**
- `pre-commit run --files …` → all applicable hooks pass
- Rendered output checked: DRA claim + `resources.claims` on jellyfin, `ResourceClaimTemplate jellyfin-gpu` present, `plex-gpu` gone and the plex Deployment carries no claim, all six volumeMounts, single `envoy-internal/https` parentRef, Homepage annotations
- Introskipper upstream ships a dedicated `12.0/v1.12.0.1` release track, so Jellyfin 12 is supported; `https://intro-skipper.org/manifest.json` is version-aware

Nothing is deployed yet — live behavior (GPU scheduling, VAAPI/QSV, plugin install, NFS library scan) is post-merge.

## Post-merge manual steps

Plugin installation has no GitOps path, so after Flux reconciles:

1. Setup wizard, add libraries from `/media`
2. Point the metadata path at `/metadata`
3. Enable hardware acceleration → Intel QuickSync / VAAPI
4. Add plugin repo `https://intro-skipper.org/manifest.json` → install **Intro Skipper** → restart
5. Optional: `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` → install **File Transformation**

Full detail, follow-ups and rationale: BM `docs/progress/jellyfin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


