### PR TITLE
🐛 fix(crosswatch): probe /healthz and align UID with the image

### DIFF
--- a/kubernetes/apps/media/crosswatch/app/helmrelease.yaml
+++ b/kubernetes/apps/media/crosswatch/app/helmrelease.yaml
@@ -13,15 +13,18 @@ spec:
     defaultPodOptions:
       automountServiceAccountToken: false
       enableServiceLinks: false
-      # AD-023: ingress admitted by the ingress-from-gateway-internal CCNP via this label
+      # AD-023: gateway ingress via the CCNP label; allow-world egress because Jellyfin
+      # matching needs TMDb metadata. Narrow to custom-egress once the destinations settle.
       labels:
         ingress.home.arpa/allow-gateway-internal: "true"
         egress.home.arpa/allow-world: "true"
       securityContext:
+        # 1000 matches the image's baked-in appuser (APP_UID default); at 10001 the
+        # entrypoint's id lookup fails and logs "cannot find name for user ID".
         runAsNonRoot: true
-        runAsUser: 10001
-        runAsGroup: 10001
-        fsGroup: 10001
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
@@ -41,14 +44,15 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-            # Probes match the upstream Dockerfile HEALTHCHECK (TCP 127.0.0.1:8787) — no
-            # HTTP path guessed; switch to httpGet once a clean health endpoint is confirmed.
+            # /healthz is the documented health endpoint and stays unauthenticated
+            # while / redirects to the login page.
             probes:
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: *port
                   periodSeconds: 30
                   timeoutSeconds: 5
@@ -58,7 +62,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: *port
                   periodSeconds: 30
                   timeoutSeconds: 5


### PR DESCRIPTION
Two small corrections to the round-1 PoC deploy, both from the upstream wiki and verified against the live pod.

**Probes: tcpSocket → httpGet /healthz.** The original probes were TCP because no health path was known. Upstream documents `GET /healthz` returning `{"ok":true,"status":"ok"}`; verified live that it answers 200 and is **not** auth-gated, while `/` returns 302 to the login page. An httpGet probe proves the app is serving, not merely that the port is bound.

**runAsUser 10001 → 1000.** The image bakes its runtime user at `APP_UID=1000`. At 10001 the entrypoint's `id` lookup fails and the boot log carries `id: cannot find name for user ID 10001`. Non-fatal — the pod runs 1/1 — but the mismatch buys nothing. The `/config` PVC currently holds an empty database (`0 items`, `0 events`), so the `fsGroup` change has nothing to disturb.

Also corrected the pod-label comment, which described only the ingress label after `egress.home.arpa/allow-world` was added, and noted the intent to narrow it to `custom-egress` once the egress destinations settle.

`TZ` deliberately stays out of the manifest: k8tz injects `Europe/Budapest` at admission, verified on the live pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)