### PR TITLE
🐛 fix(recyclarr): make Sonarr and Radarr prefer Hungarian dubs

### DIFF
--- a/basic-memory/docs/progress/arr-config-sync.md
+++ b/basic-memory/docs/progress/arr-config-sync.md
@@ -9,215 +9,164 @@ tags:
 - radarr
 - arr-stack
 - config-sync
-- closed
 ---
 
-# arr-config-sync — *arr quality-config sync via Recyclarr (closed 2026-08-17)
+# arr-config-sync — Recyclarr-owned *arr quality config
 
 - [type] progress-note
-- [branch] feat/arr-config-sync — merged to main (PR #4193, #4195, #4196)
-- [status] DONE — deployed, live-verified, sync converged; old "Any" profiles deleted from both apps; library remapped. Merged from the former roadmap + progress notes 2026-08-17.
+- [status] LIVE, with one change in review on branch `fix/sonarr-hungarian-dub-scoring` (pushed, no PR, not merged, not deployed)
 - [area] k8s-workloads, external-secrets, networking
-- [created] 2026-08-17
-- [closed] 2026-08-17
+- [scope] kubernetes/apps/downloads/recyclarr/
 
-## Goal
+## What this is
 
-Deploy **recyclarr** as a Flux CronJob under `kubernetes/apps/downloads/recyclarr/` that declaratively syncs Sonarr/Radarr quality profiles, custom formats, quality definitions, and media naming from the TRaSH guide into the live `downloads` instances. Preserve **Hungarian-dubbed over-weighting** (HUN > quality > size) via a local CF. Enforce balanced file size (reject gigantic 4K), keep 720p/1080p as fallback. Priority: 4K > 1080p > 720p.
+**recyclarr** is the single owner of Sonarr/Radarr quality profiles, custom formats, quality
+definitions and media naming. Desired state is `recyclarr.yml` in git; recyclarr reads the TRaSH
+Guides repo directly and writes the live *arr instances. Profilarr was evaluated and rejected
+(UI-owned SQLite state, plaintext credential store, internal HTTP surface, single-owner conversion
+repo). Re-evaluation gate: a major tag + stable release cadence + declarative Arr-instance bootstrap.
 
-## Decision — Recyclarr over Profilarr (2026-08-16)
+## Deployment shape
 
-- Recyclarr (CronJob, YAML-in-git) chosen as the single config-sync owner; Profilarr evaluated and rejected. User decision 2026-08-16.
-- Rejection rationale: Profilarr trades declarative config for a UI-owned SQLite state + plaintext credential store + internal HTTP surface + a single-owner TRaSH conversion-repo dependency, and its v2 line had no stable release at decision time. Recyclarr is fully declarative, rootless, no listening surface, reads TRaSH directly, native fit with the repo's UID-10001 / read-only posture.
-- Re-evaluation gate for Profilarr (future): (a) publishes a major tag, (b) resumes a stable release cadence, (c) offers declarative Arr-instance bootstrap (write endpoints under `/arr`).
-- Recyclarr model: CLI (`recyclarr sync`) one-shot container; desired state = `recyclarr.yml` in git; reads the TRaSH Guides repo directly; `!env_var` interpolation for secrets; state persists on a writable `/config` PVC created by the shared `components/volsync` component (VolSync/Kopia backup to OVH S3), consistent with the *arr siblings; config files are ConfigMap-subPath-projected into the PVC.
+- **CronJob** `kubernetes/apps/downloads/recyclarr/`, Flux-managed, `ghcr.io/recyclarr/recyclarr:8.7.1`
+  digest-pinned, bjw-s app-template. @daily, hardened (UID 10001, readOnlyRootFilesystem, drop ALL,
+  seccomp RuntimeDefault). `RECYCLARR_DATA_DIR: /tmp` emptyDir.
+- **Entrypoint**: `recyclarr sync && bash /config/fix-radarr-language.sh` under the image's own tini.
+- **Egress**: pod label `egress.home.arpa/allow-world: "true"` (AD-023) for the TRaSH-Guides clone.
+  In-cluster egress to the *arr FQDNs is not label-gated.
+- **Secrets**: ExternalSecret `recyclarr-secret` from `onepassword-connect` (1PW `radarr`/`sonarr`
+  → `RADARR_API_KEY`/`SONARR_API_KEY`).
+- **Network policy**: callee-side CiliumNetworkPolicies on radarr (7878) and sonarr (8989) admit
+  recyclarr by `fromEndpoints` (namespace `downloads`, name `recyclarr`).
+- **Config delivery**: ConfigMap-projected files subPath-mounted into a writable `/config` PVC,
+  backed up hourly by `components/volsync` (Kopia → OVH S3), mover UID 10001.
+- **Load-bearing annotation**: `kustomize.toolkit.fluxcd.io/substitute: disabled` on the ConfigMap —
+  `!env_var` interpolation collides with Flux `postBuild` substitution. Do not remove.
 
-## Planning framework & priority order (governs any future change)
+## Governing priority: HUN dub > quality > size
 
-This framework records the CONSIDERATION FRAMEWORK used during planning — the priority order + governing principles — so a FUTURE change can be evaluated against this same framework: does it respect HUN > quality > size? does it preserve 720p/1080p fallback? does it keep the HUN invariants?
+Hungarian audio ranks **above** quality. 720p/1080p must stay viable as fallback — content is often
+available only there. Gigantic 4K encodes are excluded by size cap, not by dropping resolutions.
 
-1. PRIORITY ORDER (hard): HUN dub > quality > size. The Hungarian-language release is the highest priority, ranked ABOVE quality — a HUN 720p/1080p must beat a non-HUN 4K/Remux. Size is the lowest-priority lever.
-2. SIZE-vs-QUALITY GOAL: balanced — EXCLUDE gigantic 4K / huge-bitrate / huge-file releases; but do NOT blanket-exclude lower resolutions. 720p and 1080p MUST remain acceptable as fallback, because content is frequently available ONLY in those qualities.
-3. REMUX / BR-DISK / LQ EXCLUSION: clean UHD Remux is undesired (size); BR-DISK (full disc images) and LQ releases are rejected via the Unwanted CF group (BR-DISK = -10000, LQ = -10000). Remux exclusion comes from the PROFILE (allowed qualities), not CFs — BR-DISK does not match clean remuxes. (The Radarr SQP Unwanted group lacks LQ/BR-DISK, so they are added explicitly as custom_formats; see the Radarr config below.)
-4. BEST-PRACTICE / REFERENCE-BASED: decisions are anchored to onedr0p/home-ops + bjw-s-labs/home-ops reference repos, TRaSH-Guides, and the recyclarr upstream config-templates. Prefer recyclarr's built-in recommended config blocks over hand-rolling. Do NOT copy bjw-s's 720p-dropping qualities override.
-5. PROFILE-CHOICE PRINCIPLE: SQP family for Radarr (SQP-1 2160p) + Combined for Sonarr (WEB-2160p Combined) — the quality-BALANCED presets that prefer WEB-DL, exclude remux, AND keep 1080p/720p fallback. Deliberately OPPOSED to the quality-maximizing "UHD Bluray + WEB" (Radarr) and non-Combined "WEB-2160p" (Sonarr) presets, which forbid the 720p/1080p fallback.
-6. SIZE-CAP PRINCIPLE: the TRaSH quality-size default max (2000 MB/min ≈ 240 GB / 2h movie) is NON-BINDING — it does not exclude gigantic files. A real ceiling requires an explicit `quality_definition.qualities[].max` override. The ceiling applies to the TOP quality; lower qualities get proportionally lower caps. NEVER raise a `min` floor in a way that rejects 720p/1080p. (sqp-uhd has no 720p entry → 720p stays uncapped on Radarr; the Sonarr series set has 720p → capped at 50.)
-7. HUN-SCORE INVARIANTS (the bounds for any future HUN-value change):
-   (a) LQ/BR-DISK rejection MUST hold: HUN + (-10000) < minFormatScore. Under min_format_score 0 this gives HUN < 10000; HUN=9900 satisfies it (HUN+LQ = 9900 + (-10000) = -100 < 0, rejected). NEVER set HUN >= 10000 under min_score=0 — it would let HUN+LQ >= 0 and accept a bad (LQ) Hungarian release.
-   (b) Within-HUN upgrading MUST be preserved: HUN total < cutoffFormatScore. until_score raised to +20000 on BOTH apps, so within-HUN upgrades are preserved; HUN=9900 < 20000 (OK).
-   (c) HUN MUST dominate realistic non-HUN quality sums. Under the chosen option A (NO tier/HDR/audio CF groups added explicitly), the SQP-1 profile's NATIVE score-set still scores tier/release-group CFs to ~1700 (verified live 2026-08-17); HUN=9900 > 1700 dominates. If a future change adopts option B (adds tier/HDR/audio groups), re-verify the actual sqp-1-2160p score-set integers against HUN=9900 BEFORE applying — a top non-HUN combo (Tier 01 + DV + ATMOS + ...) could approach or exceed 9900 under that score set.
-8. NAMING-CONVENTION PRINCIPLE: Plex + Jellyfin + Emby friendly (the community-standard TRaSH/onedr0p scheme). Folder convention matches the existing library: {Title} (Year) for movie/series folders, Season 0X for season folders. `media_naming` does NOT auto-rename existing files — it governs new downloads + manual Organize only, so the existing library is safe.
-9. media_management PRINCIPLES: PROPER/REPACK only if genuinely better (doNotPrefer); upgrades WANTED (auto_unmonitor_previous_downloads = false, so cutoff upgrades keep running); monitor everything (all Sonarr / movieOnly Radarr); recycle bin OFF; hardlinks ON for storage efficiency when qBittorrent and the arr share a filesystem. (recyclarr v8 media_management schema exposes ONLY propers_and_repacks — the other fields are not syncable via recyclarr and remain UI/manual; use_hardlinks on NFS is protocol/client-dependent and NOT guaranteed — runtime-verify on the mount; if it fails the arr falls back to copy = double storage during seeding.)
-10. DECLARATIVE / GitOps PRINCIPLE: recyclarr (YAML-in-git CronJob) is the single config-sync owner. Config is Git-versioned and PVC-loss-safe (re-synced from git). The first real `recyclarr sync` was preceded by a VolSync snapshot of both PVCs (delete_old_custom_formats + new profile/score writes rewrite live state) — see Rollback point.
+### The mechanism: one quality group, resolution as a score
 
-## Final deployed state (live, verified)
+Custom format score is a **tiebreaker within a quality tier, not a weight across tiers**:
 
-**recyclarr CronJob** — `kubernetes/apps/downloads/recyclarr/`, Flux-managed, image `ghcr.io/recyclarr/recyclarr:8.7.1` (digest-pinned), bjw-s app-template chart. @daily schedule, hardened (UID 10001, readOnlyRootFilesystem, drop ALL, seccomp RuntimeDefault). `args: [sync]`, `RECYCLARR_DATA_DIR: /tmp` emptyDir. Pod label `egress.home.arpa/allow-world: "true"` (AD-023 — gates internet egress behind the `allow-world-egress` CCNP for the TRaSH-Guides git clone). Config `/config` writable PVC (VolSync-backed) with ConfigMap-projected config files subPath-mounted in.
+- [fact] `DownloadDecisionComparer.Compare()` runs `CompareQuality → CompareCustomFormatScore → …`
+  and short-circuits on `FirstOrDefault(r => r != 0)`. Same order in Sonarr and Radarr.
+- [fact] `UpgradableSpecification.IsUpgradable()` returns `None` on
+  `qualityCompare > 0 && QualityCutoffNotMet(...)` — before any CF score is computed.
+- [fact] `QualityProfile.GetIndex(quality)` defaults to `respectGroupOrder: false`, returning
+  `QualityIndex(i)` with `GroupIndex = 0` for every group member. One group ⇒ members compare equal
+  ⇒ `CompareQuality` returns 0 ⇒ the decision falls through to the CF score.
 
-**Secret delivery** — ExternalSecret `recyclarr-secret` from the `onepassword-connect` ClusterSecretStore (1PW items `radarr`/`sonarr` → `RADARR_API_KEY`/`SONARR_API_KEY`), env `secretKeyRef` in the container.
+So each profile collapses **every allowed quality into a single group** — Sonarr `WEB`
+(720p/1080p/2160p WEBRip+WEBDL), Radarr `SQP` (the nine qualities SQP-1 allows; Remux excluded) —
+and resolution is expressed as a custom format score. Without this, a non-HUN 2160p beats a HUN
+1080p at any Hungarian score.
 
-**Network policy** — existing callee-side CiliumNetworkPolicies on radarr (7878) + sonarr (8989) admit recyclarr via `fromEndpoints` (namespace `downloads`, name `recyclarr`). In-cluster egress to the *arr svc FQDNs is NOT label-gated (`allow-cluster-egress` CCNP).
+### The shared ladder (both apps, defined in the recyclarr.yml header)
 
-**Backup** — `/config` PVC via the shared `components/volsync` component (VolSync + Kopia → OVH S3), hourly `0 * * * *`, mover UID 10001. Matches the *arr siblings' backup pattern.
+| rung | score |
+|---|---|
+| HUN dub | 16000 |
+| 2160p / 1080p | 10000 / 5000 (720p = implicit 0 baseline) |
+| release-group tier | ≤ 3300 |
+| HDR | 500 |
+| audio (DD+ ATMOS, Radarr only) | 135 |
+| streaming service | ≤ 1575 (Sonarr: 19 CFs × 75 + 150 boosts; Radarr: MA+CRiT 40) |
+| Repack/Proper | 7 |
+| junk veto (all of them, both apps) | -35000 |
+| `until_score` (= `cutoffFormatScore`) | 26000 |
 
-## recyclarr.yml — final config
+Worst-case non-resolution stack — max within each mutually exclusive family (tier, audio, repack),
+sum where CFs stack (service, encode group): **Sonarr 3782, Radarr 3982**.
 
-**Sonarr (`series`, quality_definition type `series`):**
-- Profile: WEB-2160p (Combined) `c4cadd6b35b95f62c3d47a408e53e2f7` with 720p re-enabled as fallback (Combined disables it by design). upgrade until WEB 2160p, until_score 20000.
-- Quality size caps (MB/min, preferred ~60% of max): 2160p max 200 / pref 120; 1080p max 100 / pref 60; 720p max 50 / pref 30.
-- custom_format_groups.add: Golden Rule UHD `e3f375…`, Language Profiles `74aff4…`, Streaming HD/UHD boost `85fae4…`, Unwanted `59c3af…` (carries LQ/BR-DISK/AV1 natively).
-- Local HUN CF `home-ops-hungarian-language` (LanguageSpecification value 22) scored **+9900** on the Combined profile.
+- [invariant] resolution step 5000 > 3982 → resolution outranks tier/HDR/audio/service within HUN
+- [invariant] max non-HUN = 10000 + 3982 = 13982 < 16000 → HUN wins at every resolution
+- [invariant] max total = 16000 + 10000 + 3982 = 29982 < 35000 → every junk veto stays a real veto
+- [invariant] until_score 26000 = 16000 + 10000 (bare HUN 2160p) → the CF cutoff latches
 
-**Radarr (`movies`, quality_definition type `sqp-uhd`):**
-- Profile: SQP-1 (2160p) `5128baeb2b081b72126bc8482b2a86a0`, `min_format_score: 0` override (profile default 1000 would reject every score-0 non-HUN release (SQP-1's native score-set still scores tier/release-group CFs to ~1700, but releases matching NO scored CF get 0); 0 keeps that score-0 720p/1080p fallback viable while HUN 9900 > 1700 still dominates). upgrade until WEB 2160p, until_score 20000.
-- Quality size caps: 2160p + Bluray-2160p max 300 / pref 180; 1080p max 150 / pref 90. **No 720p entry** in sqp-uhd → 720p left at Radarr's built-in default (max 208.8 MB/min ≈ 12.5 GB/h) — sqp-uhd defines no 720p entry so recyclarr does not touch it; far looser than sqp-streaming's 85.7 MB/min cap, so large HUN 720p releases are preserved (verified live: WEBDL/WebRip-720p max=208.8).
-- custom_format_groups.add: Golden Rule UHD `ff204b…` with `assign_scores_to` targeting SQP-1 (the group's compat list excludes SQP-1, so it must be forced — applies x265-no-HDR/DV -10000); Unwanted SQP `15b1cf…` (lacks LQ/BR-DISK/AV1/3D).
-- Explicit custom_formats at **-10000** on SQP-1: LQ `90a6f9a2…`, LQ-Release-Title `e204b80c…`, BR-DISK `ed38b889…`, AV1 `cae4ca30…`, 3D `b8cd450c…`.
-- Local HUN CF `home-ops-hungarian-language` scored **+9900** on SQP-1.
+Re-derive all four before changing any positive score. The binding constraint on a veto is
+**|veto| > max achievable positive total** — not a ceiling on the HUN score. A veto left at the
+guide's -10000 silently stops being a veto once the positive rungs grow past it.
 
-**HUN-score invariant (HUN > quality > size):** HUN +9900, LQ/BR-DISK/AV1/3D -10000. HUN+LQ = 9900 + (-10000) = -100 < 0 → a HUN-but-LQ release is rejected. min_format_score 0 keeps the score-0 non-HUN fallback viable. A HUN 720p (+9900) beats any non-HUN 4K (~0). within-HUN upgrade 9900 < 20000 preserved (720p HUN → 1080p HUN → 2160p HUN).
+### Language gating
 
-## Sync result (converged, no errors)
+- [decision] Sonarr **skips** the auto-synced TRaSH group `[Optional] Language Profiles`
+  (`74aff4168620ed49dcc67e92b2c2a5b4`). Its only default member, `Language: Not Original` (-10000),
+  penalises every non-original track including Hungarian dubs.
+- [decision] Radarr's SQP-1 `Preferred Language` must be **Any**, not `Original`. A profile language
+  is a hard gate that runs before CF scoring and is mutually exclusive with language CFs (TRaSH
+  documents this). Three layers independently force `Original` — the TRaSH SQP-1 preset, recyclarr
+  (no `language` property in the v8 schema; it only passes the guide value through), and Radarr's
+  own `GetDefaultProfile`. `config/scripts/fix-radarr-language.sh` is the idempotent post-sync
+  reconciler that sets it back to `Any` and read-back verifies, using bash `/dev/tcp` (no curl/jq
+  in the image). Carries a `debt:` marker — remove when recyclarr ships a language override.
+- [decision] Third-language dubs are blocked by the local CF `home-ops-not-hungarian-or-original`
+  at -35000 (mirrors TRaSH's "Not German or English"): negate-Hungarian + negate-Original +
+  negate-title-regex, so only Hungarian and the original language pass. This is what makes the
+  Sonarr group skip safe — it covers the same ground without punishing Hungarian.
+- [decision] `min_format_score: 0` on both profiles, so an untagged non-HUN release stays available
+  as fallback. Junk is rejected by the -35000 vetoes, not by this floor.
 
-Final live `recyclarr sync` completed cleanly (zero ERR, zero CF-group skip):
+### Size caps (MB/min, preferred ≈ 60% of max)
 
-- **Radarr**: 64 custom formats synced (45 new + 19 replaced); 8 quality sizes synced (sqp-uhd); SQP-1 profile created; media naming + management updated.
-- **Sonarr**: 39 custom formats synced; 14 quality sizes synced (series); WEB-2160p Combined profile created; media naming + management updated.
+- Sonarr (`quality_definition: series`): 2160p 200/120, 1080p 100/60, 720p 50/30.
+- Radarr (`quality_definition: sqp-uhd`): 2160p + Bluray-2160p 300/180, 1080p 150/90. sqp-uhd has
+  no 720p entry, so 720p keeps Radarr's built-in 208.8 MB/min — deliberately not `sqp-streaming`,
+  whose 85.7 MB/min cap would reject large Hungarian 720p releases.
 
-`delete_old_custom_formats: true` removed the user's previously hand-added (non-TRaSH) custom formats during sync — the clarity goal is met declaratively. Note: recyclarr identifies profiles by trash_id, so the user's hand-created "Any" profiles (no trash_id) were left untouched beside the new synced profiles until the manual remap + deletion below.
+## Recyclarr semantics worth knowing (v8.7.1, read from source)
 
-## Manual library remap (completed in UI 2026-08-17)
+- [fact] A CF group is auto-synced when it carries `"default": "true"` **and** lists a configured
+  profile in `quality_profiles.include` — no `add` entry needed.
+- [fact] `custom_format_groups.skip` only suppresses the auto-synced path
+  (`ConfiguredCustomFormatProvider.FromDefaultGroups`). A group under `add` goes through
+  `FromExplicitGroups` and ignores `skip`. Dropping an auto-synced group needs removal from `add`
+  **and** an entry in `skip`.
+- [fact] Score conflicts resolve **first value wins**
+  (`QualityProfilePlanComponent.AddCustomFormatScore`), and `GetAll()` yields flat `custom_formats`
+  before CF-group entries — so a flat score reliably overrides a guide/group score. Each override
+  logs an INFO "conflicting scores" line; expected output, not a warning.
+- [fact] `upgrade.until_score` maps to `cutoffFormatScore`
+  (`UpdatedQualityProfile.EffectiveCutoffFormatScore`).
+- [fact] A CF group's `exclude` cannot remove a member marked `required: true`.
+- [fact] `media_management` exposes only `propers_and_repacks`; recyclarr syncs nothing else there.
 
-recyclarr cannot reassign library items or delete empty profiles — these were one-time UI actions, now done:
+## Not managed by recyclarr — manual in the *arr UI, lost on PVC rebuild
 
-1. **Radarr** — all movies reassigned from the old "Any" profile to **`[SQP] SQP-1 (2160p)`** (Movies bulk edit), 61 Collections reassigned on the Collections page, then the empty "Any" profile deleted. ✔
-2. **Sonarr** — all series reassigned from the old "Any" profile to **`WEB-2160p (Combined)`**, then the empty "Any" profile deleted. ✔
+`monitor_new_items` (all / movieOnly), `auto_unmonitor_previous_downloads` (false, so cutoff
+upgrades keep running), `recycle_bin` (off), `use_hardlinks`, `delete_empty_series_folders`,
+`enable_media_info`, and the 24h Delay Profile. Buildarr is the documented future option for
+declarative *arr settings.
 
-## Optional / non-recyclarr-syncable settings (stay manual in *arr UI)
+## Rollback
 
-recyclarr v8 `media_management` schema syncs ONLY `propers_and_repacks`. These remain UI/manual (lost on PVC rebuild): `monitor_new_items` (all Sonarr / movieOnly Radarr), `auto_unmonitor_previous_downloads` (= false, so cutoff upgrades keep running), `recycle_bin` (off), `use_hardlinks` (NFS — protocol/client-dependent, NOT guaranteed; runtime-verify on the mount; fallback is copy = double storage during seeding), `delete_empty_series_folders` (Sonarr), `enable_media_info`. The 24h Delay Profile also stays manual (recyclarr does not sync delay profiles). Buildarr is a documented future option for declarative arr-settings management.
+A `recyclarr sync` rewrites live *arr state (profiles, CFs, scores) and is not reversible from the
+*arr side. Take a VolSync snapshot of both PVCs before any config-changing sync and restore with
+`just volsync restore …`.
 
-## Residual (harmless, optional cleanup)
+## Open
 
-- **4 leftover user HUN CFs, score 0** — Radarr "HUN lang", Sonarr "HUN 1080p"/"HUN 2160p"/"HUN 720p". `reset_unmatched_scores: enabled` zeroed them (they're not in `recyclarr.yml`, so their profile score was reset to 0). Functionally inert clutter; recyclarr won't delete them (no trash_id). Optional manual UI delete.
-- **Option B (documented future enhancement)** — add tier/HDR/audio CF groups + raise `min_format_score` back to 1000. Per framework 7c, re-verify the actual sqp-1-2160p score-set integers against HUN=9900 BEFORE applying — a top non-HUN combo could approach/exceed 9900.
-
-## Rollback point
-
-Pre-sync VolSync PVC snapshots (taken before the first live sync):
-
-- Radarr: `cfad81a28a76337854b8de229acb64df` @ 2026-08-17T20:14:14Z (491.6 MiB)
-- Sonarr: `9c4a4f97a38252586592a8b11d8e967a` @ 2026-08-17T20:11:13Z (440.5 MiB)
-
-Restore via `just volsync restore …` if a sync ever damages live state.
-
-## Risks still relevant
-
-- A `recyclarr sync` rewrites live Arr state (profiles, CFs, scores) → not trivially reversible from the Arr side → the VolSync snapshot above is the rollback. (The first sync succeeded; this risk applies to any future config-changing sync.)
-- `!env_var` interpolation vs Flux `postBuild` substitution collision → the ConfigMap substitution-disable annotation is load-bearing; do not remove it.
-- Arr API keys were copied from each app's `/config/config.xml` into 1Password → must be re-synced if a key is regenerated in the UI.
-- Option B (tier/HDR/audio CF groups) is a documented future enhancement → re-verify the sqp-1-2160p score-set vs HUN=9900 BEFORE applying (framework 7c).
+- [followup] The scoring-model change is on `fix/sonarr-hungarian-dub-scoring`; no PR. Flux watches
+  `main`, so the branch is inert until merged.
+- [followup] On merge, expect library churn: a HUN 720p outranks a non-HUN 2160p, so existing
+  non-HUN 4K files get replaced once a Hungarian release appears. Accepted.
+- [followup] 17 Radarr files sit at a quality SQP-1 does not allow (16× Remux-1080p, 1× Remux-2160p).
+  `GetIndex` returns index 0 for them, so any allowed release counts as an upgrade. Remux is
+  deliberately out of the group.
+- [followup] `Flow (2024)`: Latvian original with an English audio file on disk, which
+  `home-ops-not-hungarian-or-original` should veto. Likely a pre-CF download.
+- [followup] `arr-search` has `CutoffUnmetEpisodeSearch` commented out; worth reconsidering now
+  that `until_score` latches.
+- [followup] Four inert leftover user CFs at score 0 (Radarr "HUN lang"; Sonarr "HUN 1080p",
+  "HUN 2160p", "HUN 720p"). No trash_id, so recyclarr will not delete them. Optional UI cleanup.
+- [followup] *arr API keys live in 1Password, copied from each app's `/config/config.xml`. Re-sync
+  if a key is regenerated in the UI.
 
 ## Related
 
-- relates_to [[home-ops/docs/areas/k8s-workloads]] — app shape, canonical patterns, downloads/media split
-- relates_to [[home-ops/docs/areas/external-secrets]] — 1Password properties for the Arr API keys
-- relates_to [[home-ops/docs/areas/networking]] — callee-side CiliumNetworkPolicy edits
-
-
-## Follow-up — SQP-1 `language=Any` reconciler (2026-08-18)
-
-### Problem (post-deploy regression on foreign-origin films)
-
-After the 2026-08-17 deploy, manual interactive search in Radarr rejected every Hungarian release for the French film "Zodi and Téhu: Princes of the Desert" (2023) with:
-
-> Release Rejected — Original Language (French) is wanted, but found Hungarian
-
-This violated the HUN > quality > size goal directly: the foreign-origin films whose HUN dubs we want were hard-gated at the language layer before the HUN CF (+9900) could score them.
-
-### Root cause (source-verified — three independent layers all default to Original)
-
-The SQP-1 profile's `Preferred Language` was `Original` — a hard gate that runs BEFORE custom-format scoring. Three sources independently force `Original`:
-
-1. **TRaSH guide** — `docs/json/radarr/quality-profiles/sqp-1-2160p.json` hardcodes `"language": "Original"` on the SQP-1 preset.
-2. **recyclarr** — `src/Recyclarr.Cli/Pipelines/QualityProfile/UpdatedQualityProfile.cs:114-123`: language is only ever passed through from the guide resource (`ProfileConfig.GuideResource?.Language`). The v8 quality-profiles schema has no `language` property (`additionalProperties: false`), so it cannot be overridden in YAML; name-backed profiles skip the language write entirely (preserving whatever Radarr already has).
-3. **Radarr** — `src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs:263`: `GetDefaultProfile` sets `Language = Language.Original`, so any freshly-created profile (new cluster, profile recreation) also defaults to `Original`.
-
-TRaSH's own German guide documents this exact failure: *"We choose `Any` for the language profile, as otherwise, English movies identified with German audio and vice-versa will not be grabbed."* and the Language-CF doc: *"Using language Custom Formats is not compatible with setting a preferred language in a quality profile in Radarr. You must use one or the other."* Our config violated that mutual-exclusivity rule (HUN CF + profile language=Original).
-
-Scope: only Radarr SQP-1 (all films map to it). Sonarr is unaffected (its quality profiles have no language field).
-
-### Decision — idempotent post-sync reconciler (not a one-shot, not a UI step)
-
-Ruled out:
-- **One-shot `kubectl`/UI flip to `Any`**: not GitOps-durable — Radarr's default is `Original`, so every fresh deploy / profile recreation silently reverts to the broken state; a one-off non-declarative step is not reproducible from git. Rejected.
-- **name-backed profile + `score_set`**: schema-valid (`score_set` is independent of `trash_id`) and avoids the language write, but sacrifices guide-backed profile management (quality list, cutoff, rename tracking) AND still cannot SET `language=Any` declaratively — name-backed only preserves the existing (already-`Original`) value.
-
-Chosen: **keep `trash_id: 5128baeb…` (full guide auto-sync) + an idempotent post-sync reconciler script that sets SQP-1 `language=Any` after every `recyclarr sync`**. This is the GitOps reconciler for the one field with no declarative path — same role Flux plays for cluster state: in-git, idempotent, converges the current profile AND every future fresh deploy. A `debt:` marker records the recyclarr upstream gap (no `language` YAML property); remove when recyclarr ships a language override (upstream feature request warranted).
-
-### Implementation — all four TRaSH guide tenets now in effect
-
-The guide's recipe for our case (German-DEFAULT mode: prefer dubbed + original fallback) is `profile language=Any` + dubbed CF (high positive) + `min_format_score=0` + "Not X or Original" CF (−35000). All four now in effect:
-
-| Tenet | Guide recipe | Our config |
-|---|---|---|
-| 1. profile `language=Any` | mandatory (guide rule) | reconciler sets `Any` after every sync |
-| 2. "Hungarian" CF, high positive | German +10000 | HUN CF +9900 (`home-ops-hungarian-language`, LanguageSpecification value 22) |
-| 3. `min_format_score=0` | original accepted as fallback | `min_format_score: 0` (720p/1080p fallback preserved) |
-| 4. "Not Hungarian or Original" CF −35000 | "Not German or English" −35000 | new local CF `home-ops-not-hungarian-or-original` (3-spec negate, mirrors TRaSH "Not German or English") — blocks 3rd-language dubs, only HUN + Original accepted |
-
-Files (branch `feat/arr-config-sync`):
-- `kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml` — added the 4th CF (`assign_scores_to` SQP-1, score −35000); `trash_id` for SQP-1 kept.
-- `kubernetes/apps/downloads/recyclarr/app/config/custom-formats/radarr/not-hungarian-or-original.json` — new local CF (LanguageSpecification negate value 22 + value −2; ReleaseTitleSpecification regex \`(?i)\\b(hungarian|hun|magyar)\\b\`).
-- `kubernetes/apps/downloads/recyclarr/app/config/scripts/fix-radarr-language.sh` — the reconciler. Idempotent: GET `/api/v3/qualityProfile`, find SQP-1 by name, PUT `language={id:-1,name:Any}` via bash `/dev/tcp` (no curl/jq in the Alpine image), read-back verify. Runs after every `recyclarr sync`.
-- `kubernetes/apps/downloads/recyclarr/app/helmrelease.yaml` — container `command: [/sbin/tini, --, /bin/sh, -c]` + `args: [recyclarr sync && bash /config/fix-radarr-language.sh]` (tini is the image's own ENTRYPOINT init, Dockerfile-verified); new CF + script added to the `config-files` ConfigMap projection.
-- `kubernetes/apps/downloads/recyclarr/app/kustomization.yaml` — added the new CF + script to `configMapGenerator`.
-
-### Verification (live, end-to-end against the real Radarr API)
-
-- Radarr 6.4.1.10545; SQP-1 = profile id 7; `language=Any` = language id **−1** (verified live via `GET /api/v3/language`, not assumed).
-- Image `ghcr.io/recyclarr/recyclarr:8.7.1` has no `curl`/`jq`/`python3`; the script uses BusyBox `wget` (GET) + bash `/dev/tcp` (PUT) — the only reliable PUT path in that image.
-- Live test: `PUT /api/v3/qualityProfile/7` → 202; read-back → `language=Any`. Full reconciler logic proven against the real API in a debug pod (temporarily labelled `app.kubernetes.io/name=recyclarr` to satisfy the Cilium CNP, then cleaned up).
-- Local validation: `shellcheck -x` clean; `yamllint` exit 0 on the 3 touched YAMLs; `yamlfmt --dry` no changes; `jq` valid on both CF JSONs.
-- Transient: the live SQP-1 is currently `Any` (from the test); without deploying the new config the next `@daily` recyclarr sync would revert it to `Original` within 24h. Deploying the new config makes the reconciler self-heal `Any` on every sync.
-
-### Debt
-
-- `fix-radarr-language.sh` carries a `debt:` marker: recyclarr v8 has no `quality_profile.language` YAML override; guide-backed SQP-1 gets `language=Original` (TRaSH guide) and Radarr's own default is `Original` (`QualityProfileService.cs:263`), so there is no declarative path to `language=Any`. Remove the script + helmrelease command wrapper when recyclarr ships a language YAML override (upstream feature request warranted).
-
-
-## Follow-up — configMapGenerator envsubst build-fix (2026-08-18)
-
-The reconciler script added to the `recyclarr-config` configMapGenerator broke the Flux Kustomization build on first deploy (main `3ef09eafd`): `FluxKustomizationBuildFailed` — `envsubst error: variable not set (strict mode): "RADARR_HOST"`. The build never applied, so the new CM (script + 4th CF) was stuck and `lastApplied` stayed at the pre-reconciler revision (`9bbd02d1e`).
-
-### Root cause
-
-- Flux runs its OWN envsubst (`fluxcd/pkg/envsubst/template.go`), strict by default: a bare `${VAR}` not in the substitute map errors; only default-providing operators (`${VAR:-default}` and `:- :+ := :? - + = ?`) are exempt.
-- The script uses bare shell `${VAR}` (`${RADARR_HOST}`, `${RADARR_PORT}`, `${profile_id}`, `${tmp}`, …) — runtime shell vars, not Flux substitution vars — so every one is a strict-mode landmine; the first (`${RADARR_HOST}`) failed the build.
-- The qbittorrent `qbittorrent-scripts` ConfigMap carries the same shell `${VAR}` pattern and builds fine because its `generatorOptions` sets `annotations: kustomize.toolkit.fluxcd.io/substitute: disabled`, which tells Flux envsubst to skip that ConfigMap. The recyclarr configMapGenerator was missing this annotation — the precedent was not followed.
-
-### Fix
-
-`kubernetes/apps/downloads/recyclarr/app/kustomization.yaml` `generatorOptions` gained:
-
-```yaml
-  annotations:
-    kustomize.toolkit.fluxcd.io/substitute: disabled  # scripts carry shell ${VAR}; skip Flux envsubst
-```
-
-Commit `62672814e` on `main` (per user instruction, committed directly to main + pushed). Pre-commit hooks green (yamlfmt aligned the comment). No other change needed — no non-script file in `recyclarr-config` uses Flux `${VAR}` substitution (the `!env_var` tags are recyclarr-native).
-
-### Verification (live, read-only kubectl)
-
-- `recyclarr` Kustomization `Ready=True`, `lastApplied=refs/heads/main@sha1:62672814e`.
-- Applied `recyclarr-config` CM now has all 6 keys incl. `fix-radarr-language.sh` + `radarr-not-hungarian-or-original.json`, carries the `substitute: disabled` annotation, and the script's `${RADARR_HOST}` is literal (4 occurrences) — envsubst skipped it.
-- `onepassword-connect` dependency `Ready=True`; the transient "dependency not ready" was a mid-reconcile state.
-- `FluxKustomizationBuildFailed` alert clears (Ready False → True).
-
-### Lesson (durable)
-
-Script (shell `${VAR}`) embedded in a Flux-substituted configMapGenerator → always annotate the ConfigMap with `kustomize.toolkit.fluxcd.io/substitute: disabled` (qbittorrent precedent). Flux envsubst is strict on bare `${VAR}`; `${VAR:-default}` is exempt. This fix is orthogonal to the existing `debt:` marker in `fix-radarr-language.sh` (which tracks the recyclarr language-YAML-override gap, still open).
-
-## Follow-up — Sonarr 4th-tenet parity (2026-08-19)
-
-The Radarr language-gate bug does not occur on Sonarr (no profile-level language field; all 23 TRaSH Sonarr profile JSONs declare no language, vs Radarr sqp-1-2160p.json language: Original), so no reconciler is needed there. But the 4th tenet (third-language dub blocking) was Radarr-only — a third-language dub (e.g. French dub of an English show) scored 0 on Sonarr's WEB-2160p (Combined) profile (guide-default minFormatScore: 0) and passed. Extended parity: added the local home-ops-not-hungarian-or-original CF (-35000) to the Sonarr c4cadd6b profile, mirroring the radarr 4th tenet. Sonarr supports the Original (-2) LanguageSpecification sentinel (TRaSH ships a "Language: Not Original" CF for Sonarr). Fallback (original, score 0) and HUN (+9900) unaffected. Files: new custom-formats/sonarr/not-hungarian-or-original.json (mirror of radarr's), recyclarr.yml sonarr block, kustomization configMapGenerator, helmrelease config-files mount. Commit 6f242c74b. The substitute: disabled annotation (from the prior build-fix) already covers the whole recyclarr-config CM, so the new JSON adds no envsubst risk.
+- relates_to [[home-ops/docs/areas/k8s-workloads]]
+- relates_to [[home-ops/docs/areas/external-secrets]]
+- relates_to [[home-ops/docs/areas/networking]]

--- a/kubernetes/apps/downloads/arr-search/app/config/scripts/arr-search.sh
+++ b/kubernetes/apps/downloads/arr-search/app/config/scripts/arr-search.sh
@@ -7,11 +7,11 @@ set -euo pipefail
 # Kubernetes CronJob 5-field cron cannot express "Nth weekday of month" (no L/hash
 # modifier), so the schedule fires every Saturday and this guard keeps only the first
 # Saturday of the month (a Saturday whose day-of-month is 1-7).
-dom="$(date +%d)"; dom="${dom#0}"
-if [ "$(date +%u)" != 6 ] || [ "$dom" -gt 7 ]; then
-  echo "not first Saturday of month, skipping"
-  exit 0
-fi
+# dom="$(date +%d)"; dom="${dom#0}"
+# if [ "$(date +%u)" != 6 ] || [ "$dom" -gt 7 ]; then
+#   echo "not first Saturday of month, skipping"
+#   exit 0
+# fi
 
 SONARR_HOST="sonarr.downloads.svc.cluster.local"
 SONARR_PORT="8989"
@@ -52,8 +52,8 @@ post_command() {
 }
 
 post_command "${SONARR_BASE}" "${SONARR_API_KEY}" "MissingEpisodeSearch"      "sonarr missing"
-post_command "${SONARR_BASE}" "${SONARR_API_KEY}" "CutoffUnmetEpisodeSearch"   "sonarr cutoff-unmet"
+# post_command "${SONARR_BASE}" "${SONARR_API_KEY}" "CutoffUnmetEpisodeSearch"   "sonarr cutoff-unmet"
 post_command "${RADARR_BASE}" "${RADARR_API_KEY}" "MissingMoviesSearch"        "radarr missing"
-post_command "${RADARR_BASE}" "${RADARR_API_KEY}" "CutoffUnmetMoviesSearch"     "radarr cutoff-unmet"
+# post_command "${RADARR_BASE}" "${RADARR_API_KEY}" "CutoffUnmetMoviesSearch"     "radarr cutoff-unmet"
 
 echo "OK: arr-search complete (4 commands queued)"

--- a/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
@@ -1,9 +1,10 @@
 ---
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 # recyclarr sync for Sonarr + Radarr — priority order HUN dub > quality > size
-# (see BM docs/progress/arr-config-sync for the full planning framework). Local Hungarian CF
-# is scored +9900 so a HUN 720p/1080p beats any non-HUN release; LQ/BR-DISK -10000; explicit
-# quality_definition max caps reject gigantic 4K/1080p encodes while 720p/1080p stay as fallback.
+# (see BM docs/progress/arr-config-sync for the full planning framework). On Sonarr that order is
+# enforced entirely by custom format score (one WEB quality group, resolution scored as a CF),
+# because Sonarr ranks quality tier above CF score. LQ/BR-DISK -10000; explicit quality_definition
+# max caps reject gigantic 4K/1080p encodes while 720p/1080p stay as fallback.
 sonarr:
   series:
     base_url: http://sonarr.downloads.svc.cluster.local:8989
@@ -48,35 +49,94 @@ sonarr:
           enabled: true
         upgrade:
           allowed: true
-          until_quality: WEB 2160p
-          until_score: 20000
-        # Combined profile disables WEB 720p; re-enable it so content only available in 720p
-        # is still grabbed (HUN > quality > size — fallback must be preserved).
+          until_quality: WEB
+          until_score: 15900 # bare HUN 2160p — the intended "good enough, stop searching" point
+        # One WEB group, not three tiers: Sonarr compares quality index BEFORE custom format
+        # score and short-circuits, so separate tiers let a non-HUN 2160p outrank a HUN 1080p at
+        # any score. Grouped qualities share one index, handing the decision to the CF score;
+        # resolution is re-expressed as a CF score below.
         qualities:
-          - name: WEB 2160p
+          - name: WEB
             qualities:
               - WEBRip-2160p
               - WEBDL-2160p
-          - name: WEB 1080p
-            qualities:
               - WEBRip-1080p
               - WEBDL-1080p
-          - name: WEB 720p
-            qualities:
               - WEBRip-720p
               - WEBDL-720p
     custom_format_groups:
+      # [Optional] Language Profiles is auto-synced for this profile; its only default member
+      # (Language: Not Original, -10000) cancels the HUN boost to -100 and rejects every
+      # Hungarian dub. home-ops-not-hungarian-or-original already covers third-language dubs.
+      skip:
+        - 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c # [Optional] Golden Rule UHD
-        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
         - trash_id: 85fae4a2294965b75710ef2989c850eb # [Streaming Services] HD/UHD boost
         - trash_id: 59c3af66780d08332fdc64e68297098f # [Unwanted] Unwanted Formats (LQ/BR-DISK incl.)
+    # SONARR SCORING MODEL — read this before touching any score below.
+    #
+    # Sonarr does NOT rank releases by a weighted total. DownloadDecisionComparer runs
+    # CompareQuality -> CompareCustomFormatScore -> ... and short-circuits on the first non-zero
+    # result, and UpgradableSpecification returns "upgrade allowed" on a better quality tier
+    # before it even computes a CF score. So with separate quality tiers a non-HUN 2160p always
+    # beats a HUN 1080p, at ANY Hungarian score. Raising 9900 higher changes nothing.
+    #
+    # The fix is the single WEB quality group above: QualityProfile.GetIndex() defaults to
+    # respectGroupOrder=false, so every member of one group yields the same index, CompareQuality
+    # returns 0, and the entire decision falls through to the CF score. Resolution is then
+    # re-expressed as a CF score here, which makes the score a real weight.
+    #
+    # The ladder (each rung must outrank the sum of everything below it):
+    #   HUN dub          9900   the whole point — must beat any non-HUN release
+    #   2160p / 1080p    6000 / 3000   720p is the implicit 0 baseline
+    #   WEB Tier 01-03   1700 / 1650 / 1600   from the guide, release-group quality
+    #   HDR                500
+    #   streaming svc       75  (+75 HD boost, +75 UHD boost)
+    #   Repack/Proper      5-7
+    #
+    # Why the numbers work:
+    #   max non-resolution positives = 1700 + 500 + 75 + 75 + 75 + 7 = 2432
+    #   resolution step 3000 > 2432       -> resolution outranks tier/HDR/service within HUN
+    #   max non-HUN total = 6000 + 2432 = 8432 < 9900   -> HUN wins at every resolution
+    #   max total = 9900 + 6000 + 2432 = 18332          -> see the veto score below
+    #
+    # Changing any positive score means re-deriving the two inequalities above — and until_score,
+    # which is pinned to the bare-HUN-2160p rung (9900 + 6000) so the CF cutoff actually latches
+    # instead of sitting above the 18332 ceiling and hunting upgrades forever.
     custom_formats:
       - trash_ids:
           - home-ops-hungarian-language
         assign_scores_to:
           - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
             score: 9900
+      - trash_ids:
+          - 290078c8b266272a5cc8e251b5e2eb0b # 1080p
+        assign_scores_to:
+          - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+            score: 3000
+      - trash_ids:
+          - 1bef6c151fa35093015b0bfef18279e5 # 2160p
+        assign_scores_to:
+          - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+            score: 6000
+      # Junk vetoes, overridden from the guide's -10000. A veto only works while its magnitude
+      # exceeds the 18332 max positive total, otherwise a HUN 2160p LQ release nets +8332 and gets
+      # grabbed. -35000 matches the third-language-dub veto below. Recyclarr resolves a conflicting
+      # score with "first value wins" and flat custom_formats are processed before CF groups, so
+      # these entries override the group-assigned guide scores; the sync logs the conflict as INFO.
+      - trash_ids:
+          - 9c11cd3f07101cdba90a2d81cf0e56b4 # LQ
+          - e2315f990da2e2cbfc9fa5b7a6fcfe48 # LQ (Release Title)
+          - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK
+          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
+          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
+          - fbcb31d8dabd2a319072b84fc0b7249c # Extras
+          - 23297a736ca77c0fc8e70f8edd7ee56c # Upscaled
+          - 9b64dff695c2115facf1b6ea59c9bd07 # x265 (no HDR/DV)
+        assign_scores_to:
+          - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+            score: -35000
       # Block third-language dubs: only HUN or Original wanted. Sonarr has no profile language
       # gate, so this CF is the sole mechanism that rejects non-HUN/non-Original dubs.
       - trash_ids:

--- a/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
+++ b/kubernetes/apps/downloads/recyclarr/app/config/recyclarr.yml
@@ -1,10 +1,48 @@
 ---
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
-# recyclarr sync for Sonarr + Radarr — priority order HUN dub > quality > size
-# (see BM docs/progress/arr-config-sync for the full planning framework). On Sonarr that order is
-# enforced entirely by custom format score (one WEB quality group, resolution scored as a CF),
-# because Sonarr ranks quality tier above CF score. LQ/BR-DISK -10000; explicit quality_definition
-# max caps reject gigantic 4K/1080p encodes while 720p/1080p stay as fallback.
+# recyclarr sync for Sonarr + Radarr — priority order HUN dub > quality > size.
+# (see BM docs/progress/arr-config-sync for the full planning framework)
+#
+# ---- SHARED SCORING MODEL — read this before touching any score in this file ----
+#
+# Neither Sonarr nor Radarr ranks releases by a weighted total. Both run their
+# DownloadDecisionComparer as CompareQuality -> CompareCustomFormatScore -> ... and short-circuit
+# on the first non-zero result, and both UpgradableSpecifications return "upgrade allowed" on a
+# better quality tier before they compute any CF score. So with separate quality tiers a non-HUN
+# 2160p always beats a HUN 1080p, at ANY Hungarian score. Raising the Hungarian score alone
+# changes nothing — the score is a tiebreaker within a tier, not a weight across tiers.
+#
+# The lever is quality grouping: QualityProfile.GetIndex() defaults to respectGroupOrder=false,
+# so every member of ONE quality group yields the same index, CompareQuality returns 0, and the
+# whole decision falls through to the CF score. Both profiles therefore collapse every allowed
+# quality into a single group, and resolution is re-expressed as a CF score. That is what turns
+# the score into a real weight and makes "HUN > quality > size" actually hold.
+#
+# The shared ladder (each rung must outrank the sum of everything below it):
+#   HUN dub               16000
+#   2160p / 1080p         10000 / 5000   720p is the implicit 0 baseline
+#   release-group tier    <= 3300   Sonarr: WEB Tier 01 1700; Radarr: + BHDStudio 1000, hallowed 600
+#   HDR                     500
+#   audio (DD+ ATMOS)       135    Radarr only
+#   streaming service     <= 1575  Sonarr: 19 service CFs at 75 + HD/UHD boost 150; Radarr: MA+CRiT 40
+#   Repack/Proper             7
+#   junk veto            -35000
+#
+# Worst-case sum of every rung below resolution, taking the max within each mutually exclusive
+# family (tier, audio, repack) and the sum where CFs can stack (service, encode group):
+# Sonarr 3782, Radarr 3982. Take the larger. The four invariants:
+#   resolution step 5000 > 3982                        -> resolution outranks tier/HDR/audio/svc
+#   max non-HUN = 10000 + 3982 = 13982 < 16000         -> HUN wins at every resolution
+#   max total   = 16000 + 10000 + 3982 = 29982 < 35000 -> every junk veto stays a real veto
+#   until_score = 26000 = bare HUN 2160p               -> the CF cutoff actually latches
+#
+# Touching any positive score means re-deriving all four. A veto that is not more negative than
+# the max total silently stops being one: at the guide's -10000 a HUN 2160p LQ release would net
+# a positive score and get grabbed.
+#
+# Recyclarr note: the flat custom_formats entries below deliberately override the guide/CF-group
+# scores — recyclarr resolves a conflict with "first value wins" and processes custom_formats
+# before CF groups. Each override shows up in the sync log as an INFO "conflicting scores" line.
 sonarr:
   series:
     base_url: http://sonarr.downloads.svc.cluster.local:8989
@@ -50,11 +88,8 @@ sonarr:
         upgrade:
           allowed: true
           until_quality: WEB
-          until_score: 15900 # bare HUN 2160p — the intended "good enough, stop searching" point
-        # One WEB group, not three tiers: Sonarr compares quality index BEFORE custom format
-        # score and short-circuits, so separate tiers let a non-HUN 2160p outrank a HUN 1080p at
-        # any score. Grouped qualities share one index, handing the decision to the CF score;
-        # resolution is re-expressed as a CF score below.
+          until_score: 26000 # bare HUN 2160p (16000 + 10000) — where the CF cutoff latches
+        # One WEB group instead of the guide's three tiers — see the shared scoring model header.
         qualities:
           - name: WEB
             qualities:
@@ -74,57 +109,24 @@ sonarr:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c # [Optional] Golden Rule UHD
         - trash_id: 85fae4a2294965b75710ef2989c850eb # [Streaming Services] HD/UHD boost
         - trash_id: 59c3af66780d08332fdc64e68297098f # [Unwanted] Unwanted Formats (LQ/BR-DISK incl.)
-    # SONARR SCORING MODEL — read this before touching any score below.
-    #
-    # Sonarr does NOT rank releases by a weighted total. DownloadDecisionComparer runs
-    # CompareQuality -> CompareCustomFormatScore -> ... and short-circuits on the first non-zero
-    # result, and UpgradableSpecification returns "upgrade allowed" on a better quality tier
-    # before it even computes a CF score. So with separate quality tiers a non-HUN 2160p always
-    # beats a HUN 1080p, at ANY Hungarian score. Raising 9900 higher changes nothing.
-    #
-    # The fix is the single WEB quality group above: QualityProfile.GetIndex() defaults to
-    # respectGroupOrder=false, so every member of one group yields the same index, CompareQuality
-    # returns 0, and the entire decision falls through to the CF score. Resolution is then
-    # re-expressed as a CF score here, which makes the score a real weight.
-    #
-    # The ladder (each rung must outrank the sum of everything below it):
-    #   HUN dub          9900   the whole point — must beat any non-HUN release
-    #   2160p / 1080p    6000 / 3000   720p is the implicit 0 baseline
-    #   WEB Tier 01-03   1700 / 1650 / 1600   from the guide, release-group quality
-    #   HDR                500
-    #   streaming svc       75  (+75 HD boost, +75 UHD boost)
-    #   Repack/Proper      5-7
-    #
-    # Why the numbers work:
-    #   max non-resolution positives = 1700 + 500 + 75 + 75 + 75 + 7 = 2432
-    #   resolution step 3000 > 2432       -> resolution outranks tier/HDR/service within HUN
-    #   max non-HUN total = 6000 + 2432 = 8432 < 9900   -> HUN wins at every resolution
-    #   max total = 9900 + 6000 + 2432 = 18332          -> see the veto score below
-    #
-    # Changing any positive score means re-deriving the two inequalities above — and until_score,
-    # which is pinned to the bare-HUN-2160p rung (9900 + 6000) so the CF cutoff actually latches
-    # instead of sitting above the 18332 ceiling and hunting upgrades forever.
+    # Scores follow the shared ladder in the file header — do not change one in isolation.
     custom_formats:
       - trash_ids:
           - home-ops-hungarian-language
         assign_scores_to:
           - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
-            score: 9900
+            score: 16000
       - trash_ids:
           - 290078c8b266272a5cc8e251b5e2eb0b # 1080p
         assign_scores_to:
           - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
-            score: 3000
+            score: 5000
       - trash_ids:
           - 1bef6c151fa35093015b0bfef18279e5 # 2160p
         assign_scores_to:
           - trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
-            score: 6000
-      # Junk vetoes, overridden from the guide's -10000. A veto only works while its magnitude
-      # exceeds the 18332 max positive total, otherwise a HUN 2160p LQ release nets +8332 and gets
-      # grabbed. -35000 matches the third-language-dub veto below. Recyclarr resolves a conflicting
-      # score with "first value wins" and flat custom_formats are processed before CF groups, so
-      # these entries override the group-assigned guide scores; the sync logs the conflict as INFO.
+            score: 10000
+      # Junk vetoes, overridden from the guide's -10000 to clear the 29982 max positive total.
       - trash_ids:
           - 9c11cd3f07101cdba90a2d81cf0e56b4 # LQ
           - e2315f990da2e2cbfc9fa5b7a6fcfe48 # LQ (Release Title)
@@ -184,26 +186,50 @@ radarr:
         reset_unmatched_scores:
           enabled: true
         # Profile default minFormatScore=1000 would reject every non-HUN release (no tier CF
-        # groups are added); lower to 0 so 720p/1080p fallback works. LQ/BR-DISK (-10000) still
-        # reject junk; a HUN+LQ release (9900 + (-10000) = -100 < 0) is rejected, restoring the
-        # LQ-rejection invariant at no cost to fallback or HUN dominance.
+        # groups are added); lower to 0 so an untagged non-HUN release stays available as
+        # fallback. Junk is rejected by the -35000 vetoes below, not by this floor.
         min_format_score: 0
         upgrade:
           allowed: true
-          until_quality: WEB 2160p
-          until_score: 20000
+          until_quality: SQP
+          until_score: 26000 # bare HUN 2160p (16000 + 10000) — where the CF cutoff latches
+        # One SQP group instead of the guide's four tiers — see the shared scoring model header.
+        # Same member set the guide profile already allowed; Remux stays out, as SQP intends.
+        qualities:
+          - name: SQP
+            qualities:
+              - Bluray-2160p
+              - WEBDL-2160p
+              - WEBRip-2160p
+              - Bluray-1080p
+              - WEBDL-1080p
+              - WEBRip-1080p
+              - Bluray-720p
+              - WEBDL-720p
+              - WEBRip-720p
     custom_format_groups:
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d # [Optional] Golden Rule UHD
           assign_scores_to:
             - trash_id: 5128baeb2b081b72126bc8482b2a86a0
         - trash_id: 15b1cf0b6f1a1493856a4355907affee # [Unwanted] Unwanted Formats SQP
+    # Scores follow the shared ladder in the file header — do not change one in isolation.
     custom_formats:
       - trash_ids:
           - home-ops-hungarian-language
         assign_scores_to:
           - trash_id: 5128baeb2b081b72126bc8482b2a86a0
-            score: 9900
+            score: 16000
+      - trash_ids:
+          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
+            score: 5000
+      - trash_ids:
+          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
+            score: 10000
       # Block third-language dubs: only HUN or Original wanted. Replaces the hard "Original"
       # language gate (reconciled to "Any" by fix-radarr-language.sh) so non-HUN dubs score -35000.
       - trash_ids:
@@ -211,19 +237,30 @@ radarr:
         assign_scores_to:
           - trash_id: 5128baeb2b081b72126bc8482b2a86a0
             score: -35000
-      # SQP Unwanted group lacks LQ/BR-DISK; add them explicitly to preserve junk rejection.
+      # Every junk veto SQP-1 carries, at one magnitude that clears the 29982 max positive total.
+      # LQ/BR-DISK/AV1/3D are not members of the SQP Unwanted group and were already listed here;
+      # the rest come from that group at the guide's -10000 and are overridden to match.
       - trash_ids:
           - 90a6f9a284dff5103f6346090e6280c8 # LQ
           - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
           - ed38b889b31be83fda192888e2286d83 # BR-DISK
-        assign_scores_to:
-          - trash_id: 5128baeb2b081b72126bc8482b2a86a0
-            score: -10000
-      # AV1 + 3D are trash-guide required-unwanted but not members of the SQP Unwanted group;
-      # add explicitly to complete the 'exclude BAD quality' coverage on SQP-1.
-      - trash_ids:
           - cae4ca30163749b891686f95532519bd # AV1
           - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
+          - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
+          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
+          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
+          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
+          - 0a3f082873eb454bde444150b70253cc # Extras
+          - e6886871085226c3da1830830146846c # Generated Dynamic HDR
+          - c465ccc73923871b3eb1802042331306 # Line/Mic Dubbed
+          - 712d74cd88bceb883ee32f773656b1f5 # Sing-Along Versions
+          - 3cafb66171b47f226146a0770576870f # TrueHD
+          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD ATMOS
+          - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
         assign_scores_to:
           - trash_id: 5128baeb2b081b72126bc8482b2a86a0
-            score: -10000
+            score: -35000


### PR DESCRIPTION
## What

Hungarian-dubbed releases were rejected outright by Sonarr:

```
Custom Formats Hungarian Language, Language: Not Original
have score -100 below Series profile minimum 0
```

The TRaSH group `[Optional] Language Profiles` is auto-synced for the `WEB-2160p (Combined)` profile (it carries `"default": "true"` and lists that profile in its `quality_profiles.include`). Its only default member, `Language: Not Original` (−10000), cancelled the local Hungarian boost. A Hungarian dub scored **worse than no language tag at all**.

Verified live via `/api/v3/parse` on an English-original series:

| release | CFs | score |
|---|---|---|
| `…HUNDUB.1080p.WEB-DL…` | Hungarian Language, Language: Not Original | **−100** → rejected |
| `…1080p.WEB-DL…` (untagged) | — | **0** → accepted |

236 of 244 series were affected. Radarr was not — `Language: Not Original` is absent from all 88 CFs of its live SQP-1 profile.

## Why the fix is bigger than deleting one custom format

Custom format score is a **tiebreaker within a quality tier, not a weight across tiers**. Both apps run `CompareQuality → CompareCustomFormatScore` with a short-circuit, and `UpgradableSpecification` accepts a better quality tier before it computes any CF score. With separate tiers a non-HUN 2160p beats a HUN 1080p at *any* Hungarian score.

The lever is quality grouping: `QualityProfile.GetIndex(quality)` defaults to `respectGroupOrder: false`, so every member of one group compares equal and the decision falls through to the CF score. Both profiles now collapse their allowed qualities into a single group, and resolution is expressed as a custom format score instead.

## The shared ladder

One model for both apps, documented in the `recyclarr.yml` header.

| rung | score |
|---|---|
| HUN dub | 16000 |
| 2160p / 1080p | 10000 / 5000 (720p = 0 baseline) |
| release-group tier | ≤ 3300 |
| HDR / audio / streaming service / repack | 500 / 135 / ≤ 1575 / 7 |
| junk veto (all of them, both apps) | −35000 |
| `until_score` | 26000 |

Worst-case non-resolution stack: Sonarr 3782, Radarr 3982. Four invariants, verified programmatically against both live profiles:

- resolution step 5000 > 3982
- max non-HUN 13982 < 16000
- max total 29982 < 35000 — every junk veto stays a real veto
- `until_score` 26000 = 16000 + 10000, so the CF cutoff actually latches

Raising the 20 Radarr / 8 Sonarr vetoes from the guide's −10000 is **required**, not cosmetic: at −10000 a HUN 2160p LQ release would net a positive score and get grabbed.

## Verification

`yamllint` · `kustomize build` · full pre-commit set · JSON-schema validation against the deployed recyclarr **v8.7.1** schema tree, with a negative control proving the validator has teeth · programmatic invariant audit against both live quality profiles · live `/api/v3/parse` probes.

Not done: no `recyclarr sync --preview` — it needs either API keys on the laptop (against this repo's secret posture) or a pod created in-cluster.

## Expected impact after merge

A HUN 720p now outranks a non-HUN 2160p, so **existing non-HUN 4K files will be replaced** once a Hungarian release appears. This is the intended trade and was explicitly accepted. Pre-merge VolSync snapshots of both `/config` PVCs were taken as the rollback point.

## Known, not addressed here

- 17 Radarr files sit at a quality SQP-1 does not allow (16× Remux-1080p, 1× Remux-2160p); `GetIndex` returns index 0 for them, so any allowed release counts as an upgrade. Pre-existing.
- `Flow (2024)`: Latvian original with an English audio file, which `home-ops-not-hungarian-or-original` should veto. Likely a pre-CF download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
