### PR TITLE
📝 docs(progress): mark the arr scoring model as merged

### DIFF
--- a/basic-memory/docs/progress/arr-config-sync.md
+++ b/basic-memory/docs/progress/arr-config-sync.md
@@ -14,7 +14,7 @@ tags:
 # arr-config-sync — Recyclarr-owned *arr quality config
 
 - [type] progress-note
-- [status] LIVE, with one change in review on branch `fix/sonarr-hungarian-dub-scoring` (pushed, no PR, not merged, not deployed)
+- [status] LIVE — the HUN-first scoring model is merged and reconciled; it takes effect on the next @daily recyclarr sync
 - [area] k8s-workloads, external-secrets, networking
 - [scope] kubernetes/apps/downloads/recyclarr/
 


### PR DESCRIPTION
One-line status correction. The `arr-config-sync` note still claimed the HUN-first scoring model was unmerged and undeployed; PR #4229 is merged and Flux has reconciled the recyclarr ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)